### PR TITLE
fix: version detection

### DIFF
--- a/internal/version/pattern.go
+++ b/internal/version/pattern.go
@@ -17,18 +17,18 @@ type Pattern struct {
 
 // Placeholder definitions for pattern matching
 var placeholders = map[string]string{
-	"@v": `([a-zA-Z0-9._+-]+)`, // Version - required, captured
-	"@u": `[a-fA-F0-9-]+`,      // UUID
-	"@f": `[0-9]+`,             // Flags
-	"@a": `[a-zA-Z0-9_]*`,      // Architecture (amd64, arm64, etc.) - can be empty
-	"@g": `[01]`,               // GrowFileSystem flag
-	"@r": `[01]`,               // Read-only flag
-	"@t": `[0-9]+`,             // Modification time
-	"@m": `[0-7]+`,             // File mode
-	"@s": `[0-9]+`,             // File size
-	"@d": `[0-9]+`,             // Tries done
-	"@l": `[0-9]+`,             // Tries left
-	"@h": `[a-fA-F0-9]+`,       // SHA256 hash
+	"@v": `([a-zA-Z0-9._+:~-]+)`, // Version - required, captured (includes : for epoch, ~ for debian versions)
+	"@u": `[a-fA-F0-9-]+`,        // UUID
+	"@f": `[0-9]+`,               // Flags
+	"@a": `[a-zA-Z0-9_]*`,        // Architecture (amd64, arm64, etc.) - can be empty
+	"@g": `[01]`,                 // GrowFileSystem flag
+	"@r": `[01]`,                 // Read-only flag
+	"@t": `[0-9]+`,               // Modification time
+	"@m": `[0-7]+`,               // File mode
+	"@s": `[0-9]+`,               // File size
+	"@d": `[0-9]+`,               // Tries done
+	"@l": `[0-9]+`,               // Tries left
+	"@h": `[a-fA-F0-9]+`,         // SHA256 hash
 }
 
 // ParsePattern parses a match pattern string into a Pattern struct

--- a/internal/version/pattern_test.go
+++ b/internal/version/pattern_test.go
@@ -116,6 +116,20 @@ func TestPattern_ExtractVersion(t *testing.T) {
 			wantVersion: "20240115",
 			wantOK:      true,
 		},
+		{
+			name:        "debian version with epoch",
+			pattern:     "docker_@v_amd64.raw",
+			filename:    "docker_5:29.1.5-1~debian.13~trixie_amd64.raw",
+			wantVersion: "5:29.1.5-1~debian.13~trixie",
+			wantOK:      true,
+		},
+		{
+			name:        "debian version with tilde",
+			pattern:     "incus_@v_amd64.raw",
+			filename:    "incus_1:6.20-debian13-202601150536_amd64.raw",
+			wantVersion: "1:6.20-debian13-202601150536",
+			wantOK:      true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
fix version detection issue with epoch "1:blah" and tilde "3.5~blah"