### PR TITLE
fix: make clean target removes build/ directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ install:
 
 ## clean: Remove build artifacts
 clean:
-	rm -f updex
+	rm -rf build/
 	$(GO) clean
 
 ## fmt: Format Go source files


### PR DESCRIPTION
## Summary
- Fixed `clean` target to remove `build/` directory instead of `./updex`
- The binary is built to `build/updex` but the old clean target was trying to remove `./updex`

## Test plan
- [x] `make build && ls build/updex && make clean && ls build/updex 2>&1 | grep -q "No such file" && echo "PASS"` outputs `PASS`

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)