### PR TITLE
fix: make clean target removes build/ directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ install:
 
 ## clean: Remove build artifacts
 clean:
-	rm -f updex
+	rm -rf build/
 	$(GO) clean
 
 ## fmt: Format Go source files


### PR DESCRIPTION
## Summary

- Changed `rm -f updex` to `rm -rf build/` in the Makefile `clean` target
- The binary is built to `build/updex` but the old clean target was removing `./updex` (wrong path)

## Test plan

- [ ] Run `make build && ls build/updex` to confirm binary is built
- [ ] Run `make clean && ls build/updex 2>&1 | grep -q "No such file" && echo "PASS"` to confirm clean removes it

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)