### PR TITLE
fix: make clean target removes build/ directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ install:
 
 ## clean: Remove build artifacts
 clean:
-	rm -f updex
+	rm -rf build/
 	$(GO) clean
 
 ## fmt: Format Go source files


### PR DESCRIPTION
## Summary
- Fixes the `clean` Makefile target to remove `build/` directory instead of `./updex`
- The binary is built to `build/updex` but clean was removing `./updex`

Closes #30

## Test plan
- [ ] `make build && ls build/updex && make clean && ls build/updex 2>&1 | grep -q "No such file" && echo "PASS"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)