### PR TITLE
feat: add arm64 artifacts to releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,6 +56,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
       - -trimpath


### PR DESCRIPTION
## Summary

- Adds `arm64` to the `goarch` list in the GoReleaser build matrix

GoReleaser will now produce the following for each release and nightly build:
- `updex_linux_amd64.tar.gz` + `updex_linux_arm64.tar.gz`
- `frostyard-updex_*_amd64.deb/.rpm/.apk` + `frostyard-updex_*_arm64.deb/.rpm/.apk`
- Both architectures included in `checksums.txt`

No other changes are required — `CGO_ENABLED=0` is already set so Go handles cross-compilation natively, and the `nfpms` package section inherits the build matrix automatically.