### PR TITLE
refactor: Fix filepath variable shadowing in VacuumWithDetails

### DIFF
--- a/internal/sysext/manager.go
+++ b/internal/sysext/manager.go
@@ -222,7 +222,7 @@ func VacuumWithDetails(t *config.Transfer) (removed []string, kept []string, err
 
 	for i, v := range versions {
 		filename := versionToFile[v]
-		filepath := filepath.Join(targetDir, filename)
+		fullPath := filepath.Join(targetDir, filename)
 
 		// Always keep protected versions
 		if t.Transfer.ProtectVersion != "" && v == t.Transfer.ProtectVersion {
@@ -237,7 +237,7 @@ func VacuumWithDetails(t *config.Transfer) (removed []string, kept []string, err
 		}
 
 		// Remove old version
-		if err := os.Remove(filepath); err != nil {
+		if err := os.Remove(fullPath); err != nil {
 			return removed, kept, fmt.Errorf("failed to remove %s: %w", filename, err)
 		}
 		removed = append(removed, v)


### PR DESCRIPTION
In `internal/sysext/manager.go:225`, the line `filepath := filepath.Join(targetDir, filename)` shadows the imported `filepath` package with a local variable. While it doesn't cause a runtime bug in the current code (the shadowed variable is only used once), it will silently break if any `filepath.*` call is added later in that loop body, and it will likely fail linting under stricter settings. Rename the local variable to `filePath` or `fullPath`.

---
*Automated improvement by yeti improvement-identifier*