### PR TITLE
refactor: Pass context.Context through to HTTP calls for cancellation support

### DIFF
--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -1,6 +1,7 @@
 package download
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -15,7 +16,7 @@ import (
 
 // Download fetches a file from URL, verifies its hash, decompresses if needed,
 // and atomically writes it to the target path
-func Download(url, targetPath, expectedHash string, mode uint32) error {
+func Download(ctx context.Context, url, targetPath, expectedHash string, mode uint32) error {
 	// Create target directory if needed
 	targetDir := filepath.Dir(targetPath)
 	if err := os.MkdirAll(targetDir, 0755); err != nil {
@@ -38,7 +39,12 @@ func Download(url, targetPath, expectedHash string, mode uint32) error {
 		Timeout: 10 * time.Minute, // Long timeout for large files
 	}
 
-	resp, err := client.Get(url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to download: %w", err)
 	}

--- a/internal/manifest/gpg.go
+++ b/internal/manifest/gpg.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -19,9 +20,14 @@ var keyringPaths = []string{
 }
 
 // verifySignature verifies the GPG signature of the manifest content
-func verifySignature(client *http.Client, sigURL string, content []byte) error {
+func verifySignature(ctx context.Context, client *http.Client, sigURL string, content []byte) error {
 	// Download signature
-	resp, err := client.Get(sigURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sigURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create signature request: %w", err)
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to fetch signature: %w", err)
 	}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"bufio"
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -19,7 +20,7 @@ type Manifest struct {
 
 // Fetch downloads and parses a SHA256SUMS manifest from the given base URL
 // If verify is true, it will also verify the GPG signature
-func Fetch(baseURL string, verify bool) (*Manifest, error) {
+func Fetch(ctx context.Context, baseURL string, verify bool) (*Manifest, error) {
 	manifestURL := strings.TrimRight(baseURL, "/") + "/SHA256SUMS"
 
 	// Download manifest
@@ -27,7 +28,12 @@ func Fetch(baseURL string, verify bool) (*Manifest, error) {
 		Timeout: 30 * time.Second,
 	}
 
-	resp, err := client.Get(manifestURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, manifestURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch manifest: %w", err)
 	}
@@ -46,7 +52,7 @@ func Fetch(baseURL string, verify bool) (*Manifest, error) {
 	// Verify GPG signature if requested
 	if verify {
 		sigURL := manifestURL + ".gpg"
-		if err := verifySignature(client, sigURL, content); err != nil {
+		if err := verifySignature(ctx, client, sigURL, content); err != nil {
 			return nil, fmt.Errorf("signature verification failed: %w", err)
 		}
 	}

--- a/updex/features.go
+++ b/updex/features.go
@@ -146,7 +146,7 @@ func (c *Client) EnableFeature(ctx context.Context, name string, opts EnableFeat
 					result.DownloadedFiles = append(result.DownloadedFiles, transfer.Component+" (would download)")
 				} else {
 					// Use installTransfer which handles all the download logic
-					version, err := c.installTransfer(transfer, true) // noRefresh=true, we'll refresh once at the end
+					version, err := c.installTransfer(ctx, transfer, true) // noRefresh=true, we'll refresh once at the end
 					if err != nil {
 						result.Error = fmt.Sprintf("failed to download %s: %v", transfer.Component, err)
 						c.warn("%s", result.Error)
@@ -397,7 +397,7 @@ func (c *Client) UpdateFeatures(ctx context.Context, opts UpdateFeaturesOptions)
 				Component: transfer.Component,
 			}
 
-			available, err := c.getAvailableVersions(transfer)
+			available, err := c.getAvailableVersions(ctx, transfer)
 			if err != nil {
 				result.Error = fmt.Sprintf("failed to get available versions: %v", err)
 				c.warn("%s", result.Error)
@@ -434,7 +434,7 @@ func (c *Client) UpdateFeatures(ctx context.Context, opts UpdateFeaturesOptions)
 				continue
 			}
 
-			m, err := manifest.Fetch(transfer.Source.Path, c.config.Verify || transfer.Transfer.Verify)
+			m, err := manifest.Fetch(ctx, transfer.Source.Path, c.config.Verify || transfer.Transfer.Verify)
 			if err != nil {
 				result.Error = fmt.Sprintf("failed to fetch manifest: %v", err)
 				c.warn("%s", result.Error)
@@ -485,7 +485,7 @@ func (c *Client) UpdateFeatures(ctx context.Context, opts UpdateFeaturesOptions)
 
 			c.msg("Downloading version %s", versionToInstall)
 			downloadURL := transfer.Source.Path + "/" + sourceFile
-			err = download.Download(downloadURL, targetPath, expectedHash, transfer.Target.Mode)
+			err = download.Download(ctx, downloadURL, targetPath, expectedHash, transfer.Target.Mode)
 			if err != nil {
 				result.Error = fmt.Sprintf("download failed: %v", err)
 				c.warn("%s", result.Error)
@@ -567,7 +567,7 @@ func (c *Client) CheckFeatures(ctx context.Context, opts CheckFeaturesOptions) (
 		for _, transfer := range featureTransfers {
 			c.msg("Checking %s/%s", f.Name, transfer.Component)
 
-			available, err := c.getAvailableVersions(transfer)
+			available, err := c.getAvailableVersions(ctx, transfer)
 			if err != nil {
 				c.warn("failed to get available versions: %v", err)
 				continue

--- a/updex/install.go
+++ b/updex/install.go
@@ -1,6 +1,7 @@
 package updex
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 
@@ -12,9 +13,9 @@ import (
 )
 
 // installTransfer performs the update/install logic for a single transfer.
-func (c *Client) installTransfer(transfer *config.Transfer, noRefresh bool) (string, error) {
+func (c *Client) installTransfer(ctx context.Context, transfer *config.Transfer, noRefresh bool) (string, error) {
 	// Get available versions
-	m, err := manifest.Fetch(transfer.Source.Path, c.config.Verify || transfer.Transfer.Verify)
+	m, err := manifest.Fetch(ctx, transfer.Source.Path, c.config.Verify || transfer.Transfer.Verify)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch manifest: %w", err)
 	}
@@ -88,7 +89,7 @@ func (c *Client) installTransfer(transfer *config.Transfer, noRefresh bool) (str
 	// Download
 	downloadURL := transfer.Source.Path + "/" + sourceFile
 	c.debug("downloading %s → %s", downloadURL, targetPath)
-	err = download.Download(downloadURL, targetPath, expectedHash, transfer.Target.Mode)
+	err = download.Download(ctx, downloadURL, targetPath, expectedHash, transfer.Target.Mode)
 	if err != nil {
 		return "", fmt.Errorf("download failed: %w", err)
 	}

--- a/updex/list.go
+++ b/updex/list.go
@@ -1,6 +1,7 @@
 package updex
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/frostyard/updex/internal/config"
@@ -9,14 +10,14 @@ import (
 )
 
 // getAvailableVersions retrieves available versions for a transfer from remote manifest.
-func (c *Client) getAvailableVersions(transfer *config.Transfer) ([]string, error) {
+func (c *Client) getAvailableVersions(ctx context.Context, transfer *config.Transfer) ([]string, error) {
 	if transfer.Source.Type != "url-file" {
 		return nil, fmt.Errorf("unsupported source type: %s", transfer.Source.Type)
 	}
 
 	// Fetch manifest
 	c.debug("fetching manifest from %s", transfer.Source.Path)
-	m, err := manifest.Fetch(transfer.Source.Path, c.config.Verify || transfer.Transfer.Verify)
+	m, err := manifest.Fetch(ctx, transfer.Source.Path, c.config.Verify || transfer.Transfer.Verify)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
All five SDK methods (`Features`, `EnableFeature`, `DisableFeature`, `UpdateFeatures`, `CheckFeatures`) in `updex/features.go` accept a `context.Context` parameter but never use it. The context is not passed to `manifest.Fetch()` or `download.Download()`, which create their own `http.Client` without context support. This means callers cannot cancel long-running downloads or manifest fetches. Thread the context through `getAvailableVersions`, `installTransfer`, `manifest.Fetch`, and `download.Download`, using `http.NewRequestWithContext` instead of `client.Get`.

---
*Automated improvement by yeti improvement-identifier*