### PR TITLE
docs: update documentation for updex

### DIFF
--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -1,0 +1,204 @@
+# updex Overview
+
+## Purpose
+
+updex is a Go SDK and CLI for managing systemd-sysext images. It replicates
+`systemd-sysupdate` functionality for `url-file` transfers, providing
+feature-based grouping of extensions with automatic version management,
+SHA256 verification, optional GPG signing, and systemd timer integration
+for scheduled updates.
+
+## Architecture
+
+### SDK-First Design
+
+All business logic lives in the `updex/` package as a public Go API. CLI
+commands in `cmd/` are thin Cobra wrappers that parse flags, call SDK
+methods, and format output. SDK code never imports CLI packages.
+
+### Directory Layout
+
+```
+cmd/
+  updex-cli/main.go       Entry point, injects build-time version info
+  updex/
+    root.go               Root Cobra command, global flags (--definitions, --verify, --no-refresh)
+    client.go             newClient() helper mapping CLI flags to SDK ClientConfig
+    features.go           features subcommand tree (list, enable, disable, update, check)
+    features_run.go       RunE implementations calling SDK methods
+    daemon.go             daemon subcommand tree (enable, disable, status)
+
+updex/                    Public SDK package
+  updex.go                Client struct, NewClient(), core helpers
+  features.go             Features(), EnableFeature(), DisableFeature(), UpdateFeatures(), CheckFeatures()
+  list.go                 Feature listing logic
+  install.go              installTransfer() core download/install flow
+  options.go              Option structs for each operation
+  results.go              Result types returned by SDK methods
+
+internal/
+  config/                 INI parser for .transfer and .feature files
+  download/               HTTP download with SHA256 verification and decompression
+  manifest/               SHA256SUMS manifest fetch with optional GPG verification
+  sysext/                 systemd-sysext integration (refresh, merge, vacuum, symlinks)
+  systemd/                systemd timer+service unit generation and management
+  version/                Pattern matching (@v placeholder) and semantic version comparison
+  testutil/               Test HTTP server helper
+```
+
+### Dependency Flow
+
+```
+CLI (cmd/updex)
+  └── SDK (updex/)
+        ├── config      Load .transfer/.feature files
+        ├── manifest    Fetch SHA256SUMS, optional GPG verify
+        ├── download    HTTP download, hash verify, decompress
+        ├── sysext      Extension lifecycle (install, vacuum, refresh)
+        │   └── version Pattern matching, version comparison
+        └── systemd     Timer/service unit management
+```
+
+## Key Patterns
+
+### Feature Model
+
+A **feature** groups related **transfers** (components). Each transfer
+describes one downloadable extension image. Features are defined in
+`.feature` INI files; transfers in `.transfer` INI files.
+
+- Features can be enabled/disabled via drop-in files at
+  `/etc/sysupdate.d/{name}.feature.d/00-updex.conf`
+- Transfers reference features via `Features=` (OR logic) and
+  `RequisiteFeatures=` (AND logic) in `[Transfer]` section
+- Masked features cannot be enabled or disabled
+
+### Update Flow
+
+1. Load all features and their associated transfers from config paths
+2. For each enabled feature's transfers:
+   a. Fetch `SHA256SUMS` manifest from the transfer's source URL
+   b. Match filenames against source patterns to extract available versions
+   c. Compare against installed versions to find updates
+   d. Download file with SHA256 verification
+   e. Decompress if needed (xz, gz, zstd)
+   f. Update `CurrentSymlink` in target directory
+   g. Symlink into `/var/lib/extensions` for systemd-sysext
+3. Vacuum old versions (respects `InstancesMax` and `ProtectVersion`)
+4. Run `systemd-sysext refresh` to activate changes
+
+### Version Pattern Matching
+
+Transfer configs use patterns with placeholders. The key placeholder is
+`@v` for version extraction. Example: `myext_@v.raw` matches
+`myext_1.2.3.raw` and extracts version `1.2.3`.
+
+Other placeholders: `@u` (UUID), `@a` (GPT NoAuto), `@t` (time),
+`@h` (SHA256), `@m` (mode), `@s` (size), `@d`/`@l` (tries done/left).
+
+Versions are compared semantically using `hashicorp/go-version` with
+string fallback.
+
+### Configuration Loading
+
+Config files use systemd INI format loaded from priority-ordered paths:
+
+1. `/etc/sysupdate.d/` (highest priority)
+2. `/run/sysupdate.d/`
+3. `/usr/local/lib/sysupdate.d/`
+4. `/usr/lib/sysupdate.d/` (lowest priority)
+
+The `--definitions` / `-C` flag overrides these with a single custom path.
+
+Drop-in directories (`.feature.d/*.conf`, `.transfer.d/*.conf`) allow
+overriding individual settings. Systemd specifiers (`%w` for VERSION_ID,
+`%a` for architecture, etc.) are expanded in paths and patterns.
+
+### Error Conventions
+
+- Lowercase messages, no trailing punctuation
+- Wrapped with `fmt.Errorf("context: %w", err)`
+- SDK methods return `(result, error)`; CLI translates to exit codes
+
+### Testing Patterns
+
+- `t.TempDir()` for filesystem operations
+- Mock runners (`sysext.MockRunner`, `systemd.MockRunner`) for systemd commands
+- `internal/testutil` provides an HTTP test server for download/manifest tests
+- `t.Context()` for context in tests (Go 1.25)
+
+## CLI Commands
+
+| Command | SDK Method | Root | Description |
+|---------|-----------|------|-------------|
+| `features list` | `Features()` | No | Show all features with status |
+| `features enable NAME` | `EnableFeature()` | Yes | Enable feature (--now to download) |
+| `features disable NAME` | `DisableFeature()` | Yes | Disable feature (--now to remove) |
+| `features update` | `UpdateFeatures()` | Yes | Download/install updates for enabled features |
+| `features check` | `CheckFeatures()` | No | Check for available updates (read-only) |
+| `daemon enable` | — | Yes | Install systemd timer for automatic updates |
+| `daemon disable` | — | Yes | Remove systemd timer |
+| `daemon status` | — | No | Show timer state |
+
+### Global Flags
+
+| Flag | Description |
+|------|-------------|
+| `-C, --definitions PATH` | Custom config directory |
+| `--verify` | Enable GPG signature verification |
+| `--no-refresh` | Skip `systemd-sysext refresh` after operations |
+| `--json` | Output in JSON format |
+| `-v, --verbose` | Enable verbose/debug output |
+
+## Configuration Files
+
+### .feature File Format
+
+```ini
+[Feature]
+Description=Human-readable description
+Documentation=https://example.com/docs
+Enabled=true
+```
+
+### .transfer File Format
+
+```ini
+[Transfer]
+MinVersion=1.0.0
+ProtectVersion=%w
+Verify=false
+InstancesMax=3
+Features=feature-name
+RequisiteFeatures=required-feature
+
+[Source]
+Type=url-file
+Path=https://example.com/releases/
+MatchPattern=myext_@v.raw.xz
+
+[Target]
+Type=regular-file
+Path=/opt/extensions/
+MatchPattern=myext_@v.raw
+CurrentSymlink=myext.raw
+```
+
+### Key Config Fields
+
+| Field | Section | Description |
+|-------|---------|-------------|
+| `Features` | Transfer | Feature names this transfer belongs to (OR logic) |
+| `RequisiteFeatures` | Transfer | All listed features must be enabled (AND logic) |
+| `InstancesMax` | Transfer | Max versions to keep (vacuum removes oldest) |
+| `ProtectVersion` | Transfer | Version string to protect from vacuum |
+| `MinVersion` | Transfer | Minimum version to consider |
+| `Type` | Source/Target | Only `url-file` / `regular-file` supported |
+| `Path` | Source | Base URL for manifest and downloads |
+| `MatchPattern(s)` | Source/Target | Filename pattern(s) with `@v` placeholder |
+| `CurrentSymlink` | Target | Symlink name pointing to current version |
+
+## Detailed Documentation
+
+- [SDK API Reference](sdk-api.md) — Public types, methods, options, and result structures
+- [Internal Packages](internal-packages.md) — Config parsing, downloads, manifests, sysext, systemd, versioning

--- a/yeti/internal-packages.md
+++ b/yeti/internal-packages.md
@@ -1,0 +1,244 @@
+# Internal Packages
+
+## config — Configuration Parser
+
+**Files:** `internal/config/feature.go`, `internal/config/transfer.go`
+
+Loads and parses `.transfer` and `.feature` INI files from systemd-style
+search paths with drop-in directory support and systemd specifier expansion.
+
+### Key Types
+
+**Transfer** — parsed transfer configuration:
+- `Component` (string) — derived from filename (e.g., `myext` from `myext.transfer`)
+- `FilePath` (string) — source config file path
+- `Transfer` (TransferSection) — `MinVersion`, `ProtectVersion`, `Verify`, `InstancesMax`, `Features`, `RequisiteFeatures`
+- `Source` (SourceSection) — `Type`, `Path`, `MatchPattern`, `MatchPatterns`
+- `Target` (TargetSection) — `Type`, `Path`, `MatchPattern`, `MatchPatterns`, `CurrentSymlink`, `Mode`, `ReadOnly`
+
+**Feature** — parsed feature configuration:
+- `Name`, `FilePath`, `Description`, `Documentation`, `AppStream`
+- `Enabled` (bool), `Masked` (bool)
+- `Transfers` ([]string) — component names derived from `Features`/`RequisiteFeatures` mapping
+
+### Key Functions
+
+- `LoadTransfers(paths ...string)` — loads all `.transfer` files from search paths
+- `LoadFeatures(paths ...string)` — loads all `.feature` files from search paths
+- `FilterTransfersByFeatures(transfers, features)` — returns transfers matching enabled features
+- `GetTransfersForFeature(transfers, featureName)` — returns transfers for a specific feature
+- `expandSpecifiers(s)` — expands `%w` (VERSION_ID), `%a` (architecture), etc.
+
+### Drop-in Support
+
+For a file `foo.transfer`, settings can be overridden by files in
+`foo.transfer.d/*.conf`. Drop-ins are loaded in alphabetical order;
+later values override earlier ones. The SDK uses
+`/etc/sysupdate.d/{name}.feature.d/00-updex.conf` to enable/disable
+features.
+
+---
+
+## download — HTTP Downloads
+
+**Files:** `internal/download/download.go`, `internal/download/decompress.go`
+
+Downloads files from URLs with SHA256 hash verification, automatic
+decompression, and atomic file writes.
+
+### Key Functions
+
+- `Download(ctx, url, destPath, expectedHash, reporter)` — main entry point:
+  1. Creates temp file in destination directory
+  2. Downloads with progress reporting
+  3. Verifies SHA256 hash
+  4. Decompresses if needed (detected from filename extension)
+  5. Atomically renames to destination (falls back to copy for cross-device)
+
+- `DecompressReader(r, filename)` — returns streaming decompression reader
+  based on file extension (`.xz`, `.gz`, `.zst`/`.zstd`)
+
+### Hash Verification
+
+`HashVerifyReader` wraps an `io.Reader`, computing SHA256 incrementally
+during read. After the full content is consumed, `Verify(expected)` checks
+the computed hash matches.
+
+---
+
+## manifest — SHA256SUMS Fetching
+
+**Files:** `internal/manifest/manifest.go`, `internal/manifest/gpg.go`
+
+Fetches and parses SHA256SUMS manifests from remote URLs with optional
+GPG signature verification.
+
+### Key Types
+
+**Manifest** — parsed manifest:
+- `URL` (string) — source URL
+- `Entries` (map[string]string) — filename → SHA256 hash
+
+### Key Functions
+
+- `Fetch(ctx, baseURL, verify)` — downloads `{baseURL}/SHA256SUMS`, parses
+  entries, optionally verifies `{baseURL}/SHA256SUMS.gpg` signature
+- `VerifyHash(filePath, expectedHash)` — verify a file's SHA256
+- `VerifyHashReader(r, expectedHash)` — verify a stream's SHA256
+
+### GPG Verification
+
+When `verify=true`:
+1. Downloads `SHA256SUMS.gpg` alongside the manifest
+2. Loads system keyring from `/etc/systemd/import-pubring.gpg` or
+   `/usr/lib/systemd/import-pubring.gpg`
+3. Verifies signature using `golang.org/x/crypto/openpgp`
+
+---
+
+## sysext — systemd-sysext Integration
+
+**Files:** `internal/sysext/manager.go`, `internal/sysext/runner.go`, `internal/sysext/mock_runner.go`
+
+Manages systemd-sysext extension lifecycle: querying installed versions,
+updating symlinks, vacuuming old versions, and triggering merge/unmerge/refresh.
+
+### Key Interface
+
+```go
+type SysextRunner interface {
+    Refresh(ctx) error
+    Merge(ctx) error
+    Unmerge(ctx) error
+    List(ctx) (string, error)
+}
+```
+
+`DefaultRunner` executes real `systemd-sysext` commands.
+`MockRunner` records calls for testing and returns configured errors.
+
+### Key Functions
+
+- `GetInstalledVersions(transfer)` — lists versions in target path,
+  identifies current version from symlink or newest file
+- `GetActiveVersion(transfer)` — checks if extension is currently active
+  (merged) via symlink or `/run/extensions`
+- `UpdateSymlink(transfer, version)` — creates/updates `CurrentSymlink`
+  pointing to the specified version
+- `LinkToSysext(transfer, version)` / `UnlinkFromSysext(transfer)` —
+  manages symlinks in `/var/lib/extensions`
+- `Vacuum(transfer)` / `VacuumWithDetails(transfer)` — removes old
+  versions keeping `InstancesMax`, protects `ProtectVersion`
+- `RemoveAllVersions(transfer)` — removes all files and symlinks
+- `Refresh(ctx, runner)` / `Merge(ctx, runner)` / `Unmerge(ctx, runner)` —
+  delegates to `SysextRunner`
+- `GetExtensionName(filename)` — extracts extension name by stripping
+  version suffix and known extensions (`.raw`, `.raw.xz`, etc.)
+
+### Extension Directory
+
+Extensions are symlinked into `/var/lib/extensions/{name}` where
+systemd-sysext discovers them. The symlink points to the actual file
+in the transfer's target path.
+
+---
+
+## systemd — Timer/Service Management
+
+**Files:** `internal/systemd/manager.go`, `internal/systemd/runner.go`, `internal/systemd/unit.go`
+
+Generates and manages systemd timer+service units for scheduling automatic
+updates via the `daemon` CLI commands.
+
+### Key Types
+
+```go
+type TimerConfig struct {
+    Name, Description string
+    OnCalendar        string // e.g., "daily"
+    Persistent        bool
+    RandomDelaySec    string
+}
+
+type ServiceConfig struct {
+    Name, Description string
+    ExecStart         string
+    Type              string // e.g., "oneshot"
+}
+```
+
+### Key Functions
+
+- `GenerateTimer(cfg)` / `GenerateService(cfg)` — produce unit file content
+- `Manager.Install(timerCfg, serviceCfg)` — writes unit files, runs
+  `daemon-reload`, enables and starts timer
+- `Manager.Remove(name)` — stops timer, disables, removes files,
+  runs `daemon-reload`
+- `Manager.Exists(name)` — checks if timer or service file exists
+
+### SystemctlRunner Interface
+
+```go
+type SystemctlRunner interface {
+    DaemonReload(ctx) error
+    Enable(ctx, unit) error
+    Disable(ctx, unit) error
+    Start(ctx, unit) error
+    Stop(ctx, unit) error
+    IsActive(ctx, unit) (bool, error)
+    IsEnabled(ctx, unit) (bool, error)
+}
+```
+
+Unit files are written to `/etc/systemd/system/`.
+
+---
+
+## version — Pattern Matching & Comparison
+
+**Files:** `internal/version/pattern.go`
+
+Parses version patterns with `@v` and other placeholders, extracts
+versions from filenames, and compares versions semantically.
+
+### Key Types
+
+**Pattern** — compiled pattern with regex and template:
+- Created via `ParsePattern(s)` which validates `@v` is present
+- Placeholders are converted to regex capture groups
+
+### Placeholders
+
+| Placeholder | Meaning |
+|-------------|---------|
+| `@v` | Version (required) |
+| `@u` | UUID |
+| `@a` | GPT NoAuto flag |
+| `@g` | GrowFileSystem flag |
+| `@r` | Read-only flag |
+| `@t` | Timestamp |
+| `@m` | File mode |
+| `@s` | File size |
+| `@d` | Tries done |
+| `@l` | Tries left |
+| `@h` | SHA256 hash |
+
+### Key Functions
+
+- `ParsePattern(s)` — compiles pattern to regex, validates `@v` present
+- `Pattern.ExtractVersion(filename)` — returns version string or empty
+- `Pattern.Matches(filename)` — checks if filename matches pattern
+- `Pattern.BuildFilename(version)` — constructs filename from template
+- `ExtractVersionMulti(filename, patterns)` — tries multiple patterns
+- `Compare(a, b)` — semantic comparison via `hashicorp/go-version`,
+  string fallback; returns -1, 0, or 1
+- `Sort(versions)` — sorts descending (newest first)
+
+---
+
+## testutil — Test Helpers
+
+**Files:** `internal/testutil/httpserver.go`
+
+Provides `NewHTTPServer(t, files)` which creates an `httptest.Server`
+serving a map of path → content. Used by download and manifest tests.

--- a/yeti/sdk-api.md
+++ b/yeti/sdk-api.md
@@ -1,0 +1,208 @@
+# SDK API Reference
+
+## Client
+
+### Construction
+
+```go
+client := updex.NewClient(updex.ClientConfig{
+    Definitions: "",              // Custom config path (empty = systemd defaults)
+    Verify:      false,           // GPG signature verification
+    Verbose:     false,           // Debug output
+    Progress:    reporter,        // reporter.Reporter for progress updates
+    SysextRunner: nil,            // Mock runner for testing
+})
+```
+
+`ClientConfig.Progress` defaults to `NoopReporter` if nil.
+`ClientConfig.SysextRunner` is only used in tests to inject `sysext.MockRunner`.
+
+## Methods
+
+### Features
+
+```go
+func (c *Client) Features(ctx context.Context) ([]FeatureInfo, error)
+```
+
+Returns all configured features with their current status. Loads feature
+configs from search paths, resolves drop-ins, and checks enabled state.
+
+### EnableFeature
+
+```go
+func (c *Client) EnableFeature(ctx context.Context, name string, opts EnableFeatureOptions) (*FeatureActionResult, error)
+```
+
+Enables a feature by writing a drop-in at
+`/etc/sysupdate.d/{name}.feature.d/00-updex.conf` with `Enabled=true`.
+
+**Options:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `Now` | bool | Download extensions immediately after enabling |
+| `DryRun` | bool | Preview changes without modifying filesystem |
+| `NoRefresh` | bool | Skip `systemd-sysext refresh` after download |
+
+**Validation:** Feature must exist and not be masked.
+
+When `Now=true`: loads transfers for the feature, calls `installTransfer()`
+for each, then refreshes sysext.
+
+### DisableFeature
+
+```go
+func (c *Client) DisableFeature(ctx context.Context, name string, opts DisableFeatureOptions) (*FeatureActionResult, error)
+```
+
+Disables a feature by writing a drop-in with `Enabled=false`.
+
+**Options:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `Now` | bool | Unmerge extensions and remove all files |
+| `Remove` | bool | *Deprecated* — use `Now` instead |
+| `Force` | bool | Allow removal of merged extensions (requires reboot) |
+| `DryRun` | bool | Preview changes without modifying filesystem |
+| `NoRefresh` | bool | Skip `systemd-sysext refresh` |
+
+**Validation:** Checks merge state before removal; requires `Force=true`
+if extensions are currently active.
+
+With `Now=true`: unmerges extensions, removes symlinks from
+`/var/lib/extensions`, and clears all versions from target directory.
+
+### UpdateFeatures
+
+```go
+func (c *Client) UpdateFeatures(ctx context.Context, opts UpdateFeaturesOptions) ([]UpdateFeaturesResult, error)
+```
+
+Downloads and installs new versions for all enabled features.
+
+**Options:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `NoRefresh` | bool | Skip `systemd-sysext refresh` after update |
+| `NoVacuum` | bool | Skip removing old versions |
+
+**Process:**
+1. Load all features and transfers
+2. Filter to enabled, non-masked features
+3. For each transfer: fetch manifest, extract versions, check for updates
+4. Download and install latest version
+5. Update symlinks
+6. Vacuum old versions (unless `NoVacuum`)
+7. Refresh sysext (unless `NoRefresh`)
+
+### CheckFeatures
+
+```go
+func (c *Client) CheckFeatures(ctx context.Context, opts CheckFeaturesOptions) ([]CheckFeaturesResult, error)
+```
+
+Read-only check for available updates across all enabled features.
+
+**Options:** None (empty struct).
+
+Returns per-component current version, newest available version, and
+whether an update is available.
+
+## Result Types
+
+### FeatureInfo
+
+Returned by `Features()`.
+
+```go
+type FeatureInfo struct {
+    Name          string   `json:"name"`
+    Description   string   `json:"description,omitempty"`
+    Documentation string   `json:"documentation,omitempty"`
+    Enabled       bool     `json:"enabled"`
+    Masked        bool     `json:"masked,omitempty"`
+    Source        string   `json:"source"`           // Config file path
+    Transfers     []string `json:"transfers,omitzero"` // Associated component names
+}
+```
+
+### FeatureActionResult
+
+Returned by `EnableFeature()` and `DisableFeature()`.
+
+```go
+type FeatureActionResult struct {
+    Feature           string   `json:"feature"`
+    Action            string   `json:"action"`            // "enable" or "disable"
+    Success           bool     `json:"success"`
+    DropIn            string   `json:"dropIn,omitempty"`   // Path to created drop-in
+    Error             string   `json:"error,omitempty"`
+    NextActionMessage string   `json:"nextActionMessage,omitempty"`
+    RemovedFiles      []string `json:"removedFiles,omitzero"`
+    DownloadedFiles   []string `json:"downloadedFiles,omitzero"`
+    DryRun            bool     `json:"dryRun,omitempty"`
+    Unmerged          bool     `json:"unmerged,omitempty"`
+}
+```
+
+### UpdateFeaturesResult / UpdateResult
+
+Returned by `UpdateFeatures()`.
+
+```go
+type UpdateFeaturesResult struct {
+    Feature string         `json:"feature"`
+    Results []UpdateResult `json:"results"`
+}
+
+type UpdateResult struct {
+    Component         string `json:"component"`
+    Version           string `json:"version,omitempty"`
+    Downloaded        bool   `json:"downloaded,omitempty"`
+    Installed         bool   `json:"installed,omitempty"`
+    Error             string `json:"error,omitempty"`
+    NextActionMessage string `json:"nextActionMessage,omitempty"`
+}
+```
+
+### CheckFeaturesResult / CheckResult
+
+Returned by `CheckFeatures()`.
+
+```go
+type CheckFeaturesResult struct {
+    Feature string        `json:"feature"`
+    Results []CheckResult `json:"results"`
+}
+
+type CheckResult struct {
+    Component       string `json:"component"`
+    CurrentVersion  string `json:"currentVersion,omitempty"`
+    NewestVersion   string `json:"newestVersion,omitempty"`
+    UpdateAvailable bool   `json:"updateAvailable"`
+}
+```
+
+## Internal Helpers
+
+### getAvailableVersions
+
+```go
+func (c *Client) getAvailableVersions(ctx context.Context, transfer *config.Transfer) ([]string, *manifest.Manifest, error)
+```
+
+Fetches the remote manifest for a transfer and extracts available versions.
+Returns sorted versions (newest first) and the manifest (for hash lookup
+during download). Validates source type is `url-file`, applies
+`MinVersion` filter.
+
+### installTransfer
+
+```go
+func (c *Client) installTransfer(ctx context.Context, transfer *config.Transfer, noRefresh bool) (string, error)
+```
+
+Core install logic for a single transfer. Used by `EnableFeature` with
+`Now=true`. Fetches manifest, selects newest version, downloads with hash
+verification, decompresses, updates symlinks, links to
+`/var/lib/extensions`, refreshes sysext, and vacuums.


### PR DESCRIPTION
## Summary

Add comprehensive project documentation covering the SDK API, internal package architecture, and system overview. These docs provide a reference for contributors and users of the updex Go SDK and CLI.

## Changes

- Added `yeti/OVERVIEW.md` — high-level architecture, feature model, update flow, CLI command reference, configuration file formats, and version pattern matching
- Added `yeti/sdk-api.md` — public SDK API reference covering `Client` construction, all methods (`Features`, `EnableFeature`, `DisableFeature`, `UpdateFeatures`, `CheckFeatures`), option structs, and result types
- Added `yeti/internal-packages.md` — documentation for internal packages: config parsing, HTTP downloads with hash verification, SHA256SUMS manifest fetching with GPG support, systemd-sysext integration, timer/service management, version pattern matching, and test utilities