### PR TITLE
docs: update documentation for updex

### DIFF
--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -1,0 +1,176 @@
+# updex Documentation
+
+## Purpose
+
+updex is a Go SDK and CLI for managing [systemd-sysext](https://www.freedesktop.org/software/systemd/man/latest/systemd-sysext.html) images. It replicates `systemd-sysupdate` functionality for `url-file` transfers, providing feature-based management of system extensions with version tracking, SHA256 verification, optional GPG signing, and automatic cleanup.
+
+The project follows an **SDK-first design**: all logic lives in public Go packages, and the CLI is a thin wrapper that parses flags and formats output.
+
+## Architecture
+
+```
+cmd/updex-cli/main.go          Entry point (frostyard/clix bootstrap)
+cmd/updex/root.go               Cobra root command, global flags
+cmd/updex/features.go           features list|enable|disable|update|check
+cmd/updex/features_run.go       Run functions for feature subcommands
+cmd/updex/daemon.go             daemon enable|disable|status (systemd timers)
+cmd/updex/client.go             CLI → SDK client factory
+
+updex/                          Public SDK (Client + methods)
+  updex.go                      Client struct, NewClient()
+  features.go                   Features(), EnableFeature(), DisableFeature()
+  install.go                    UpdateFeatures(), installTransfer()
+  list.go                       CheckFeatures(), getAvailableVersions()
+  options.go                    Option structs for all operations
+  results.go                    Result structs for all operations
+
+config/                         .transfer and .feature INI file parsing
+download/                       HTTP download with SHA256 + decompression
+manifest/                       SHA256SUMS manifest fetch/parse + GPG verify
+version/                        Pattern matching (@v placeholder) + semver compare
+sysext/                         systemd-sysext operations (refresh/merge/vacuum)
+systemd/                        systemd unit generation + systemctl management
+internal/testutil/              HTTP test server helpers (module-internal)
+```
+
+### Package dependency flow
+
+```
+CLI (cmd/) → SDK (updex/) → config, download, manifest, version, sysext
+                         → sysext → config, version
+CLI (cmd/daemon.go) → systemd (direct, bypasses SDK)
+```
+
+> Note: `cmd/updex/daemon.go` imports `systemd` directly rather than through the SDK layer. This is a known architectural deviation from the SDK-first pattern.
+
+## Key Patterns
+
+### SDK conventions
+
+- All public SDK methods take `context.Context` as first parameter for cancellation
+- Operations use dedicated option structs (e.g., `EnableFeatureOptions`, `UpdateFeaturesOptions`) to allow future expansion without breaking changes
+- Return dedicated result structs with status fields + error
+- Error messages: lowercase, no trailing punctuation, wrapped with `fmt.Errorf("context: %w", err)`
+
+### Testing patterns
+
+- Mock interfaces for system commands: `sysext.SysextRunner`, `systemd.SystemctlRunner`
+- Global runner injection via `SetRunner()` returning cleanup function
+- `ClientConfig.SysextRunner` field for injecting mocks into the SDK client
+- `internal/testutil.NewTestServer()` creates `httptest.Server` with configurable manifests and file content
+- `t.TempDir()` for filesystem operations, `t.Context()` for context
+
+### CLI output
+
+- Text tables by default, JSON with `--json` flag via `common.OutputJSON()`
+- Operations requiring filesystem changes call `requireRoot()` to enforce root access
+
+### Public API (Issue #13)
+
+All core packages (`config`, `version`, `download`, `manifest`, `sysext`, `systemd`) are exported as public API at `github.com/frostyard/updex/<package>`. Only `internal/testutil` remains internal. This was an intentional decision: the types in these packages (e.g., `Transfer`, `Feature`, `Pattern`, `Manifest`) were designed with exported fields and are suitable for external consumption.
+
+## Configuration
+
+### Search paths (priority order)
+
+1. `/etc/sysupdate.d/` (highest priority)
+2. `/run/sysupdate.d/`
+3. `/usr/local/lib/sysupdate.d/`
+4. `/usr/lib/sysupdate.d/`
+
+Only the first occurrence of a given filename is used. The `-C` flag overrides all search paths with a custom directory.
+
+### File types
+
+See [Configuration Reference](config-reference.md) for detailed format documentation.
+
+- **`.feature`** files define features (name, description, enabled state)
+- **`.transfer`** files define how components are downloaded and installed
+- **`.feature.d/`** drop-in directories override feature settings (applied alphabetically)
+
+### Key transfer settings
+
+| Setting | Section | Default | Description |
+|---------|---------|---------|-------------|
+| `InstancesMax` | `[Transfer]` | `2` | Max versions to keep on disk |
+| `ProtectVersion` | `[Transfer]` | — | Version that is never removed |
+| `MinVersion` | `[Transfer]` | — | Minimum version to consider |
+| `Verify` | `[Transfer]` | `false` | Require GPG signature verification |
+| `Features` | `[Transfer]` | — | OR list: any enabled feature activates this transfer |
+| `RequisiteFeatures` | `[Transfer]` | — | AND list: all must be enabled |
+| `CurrentSymlink` | `[Target]` | — | Symlink name pointing to current version |
+
+### GPG verification
+
+When enabled, fetches `SHA256SUMS.gpg` (detached signature) and verifies against keyrings at:
+1. `/etc/systemd/import-pubring.gpg`
+2. `/usr/lib/systemd/import-pubring.gpg`
+
+Uses `golang.org/x/crypto/openpgp` (deprecated; migration to ProtonMail/go-crypto planned).
+
+### Systemd specifiers
+
+Transfer file values support systemd-style `%` specifiers. See [Configuration Reference](config-reference.md#systemd-specifiers) for the full list.
+
+## Data Flow
+
+### Feature update (end-to-end)
+
+1. Load all `.feature` and `.transfer` files from search paths
+2. Filter transfers to those matching enabled features
+3. For each transfer:
+   - Fetch `SHA256SUMS` manifest from source URL (+ GPG verify if configured)
+   - Extract available versions using pattern matching (`@v` placeholder)
+   - Select newest version via semver comparison
+   - Skip if already installed (check target directory)
+   - Download file, verify SHA256 hash during transfer
+   - Decompress if needed (xz, gz, zstd — detected from filename)
+   - Atomically rename to final path, update `CurrentSymlink`
+   - Create symlink in `/var/lib/extensions/` pointing to extension
+   - Vacuum old versions per `InstancesMax`
+4. Call `systemd-sysext refresh` to reload all extensions (unless `--no-refresh`)
+
+### Enable/disable feature
+
+- **Enable**: Creates a drop-in file in `/etc/sysupdate.d/<name>.feature.d/` setting `Enabled=true`. With `--now`, also downloads extensions immediately.
+- **Disable**: Creates drop-in setting `Enabled=false`. With `--now`, also unmerges and removes extension files. `--force` allows removal of currently merged extensions.
+
+## CLI Commands
+
+```
+updex features list                     List all features with status
+updex features enable <name>            Enable a feature
+  --now                                 Download extensions immediately
+  --dry-run                             Preview without modifying filesystem
+updex features disable <name>           Disable a feature
+  --now                                 Unmerge and remove files immediately
+  --force                               Allow removal of merged extensions
+  --dry-run                             Preview without modifying filesystem
+updex features update                   Download and install new versions
+  --no-vacuum                           Skip removing old versions
+updex features check                    Check for available updates
+
+updex daemon enable                     Install daily auto-update timer
+updex daemon disable                    Remove auto-update timer
+updex daemon status                     Show timer status
+
+Global flags:
+  -C, --definitions <path>              Custom path to config files
+  --verify                              Enable GPG verification
+  --no-refresh                          Skip systemd-sysext refresh
+  --json                                Output as JSON
+```
+
+## Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `github.com/spf13/cobra` | CLI framework |
+| `github.com/frostyard/clix` | CLI utilities (output formatting, reporters) |
+| `github.com/frostyard/std` | Standard library extensions |
+| `github.com/hashicorp/go-version` | Semantic version comparison |
+| `github.com/schollz/progressbar/v3` | Download progress bars |
+| `gopkg.in/ini.v1` | INI file parsing |
+| `github.com/ulikunitz/xz` | XZ decompression |
+| `github.com/klauspost/compress` | ZSTD decompression |
+| `golang.org/x/crypto/openpgp` | GPG signature verification |

--- a/yeti/config-reference.md
+++ b/yeti/config-reference.md
@@ -1,0 +1,157 @@
+# Configuration Reference
+
+updex uses INI-format configuration files loaded from systemd-style search paths.
+
+## Search Paths
+
+Searched in priority order (first occurrence of a filename wins):
+
+1. `/etc/sysupdate.d/`
+2. `/run/sysupdate.d/`
+3. `/usr/local/lib/sysupdate.d/`
+4. `/usr/lib/sysupdate.d/`
+
+The `-C` / `--definitions` flag overrides all paths with a single custom directory.
+
+## Feature Files (`.feature`)
+
+Define a named feature that groups one or more transfers.
+
+**Filename**: `<name>.feature` (e.g., `devel.feature`)
+
+```ini
+[Feature]
+Description=Developer tools and headers
+Documentation=https://example.com/docs/devel
+AppStream=https://example.com/appstream/devel.xml
+Enabled=true
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `Description` | string | Human-readable description |
+| `Documentation` | string | URL to documentation |
+| `AppStream` | string | AppStream catalog XML URL |
+| `Enabled` | bool | Whether the feature is active (`true`/`false`) |
+
+### Masked features
+
+A feature is **masked** when its file is a symlink to `/dev/null`. Masked features are always treated as disabled regardless of the `Enabled` setting.
+
+### Drop-in files
+
+Features support drop-in overrides in `<name>.feature.d/*.conf` directories alongside the feature file. Drop-ins are applied in alphabetical order and can override any `[Feature]` setting.
+
+Example: `/etc/sysupdate.d/devel.feature.d/99-override.conf`
+```ini
+[Feature]
+Enabled=false
+```
+
+## Transfer Files (`.transfer`)
+
+Define how a single component (e.g., a kernel image, extension image) is downloaded, verified, and installed.
+
+**Filename**: `<component>.transfer` (e.g., `kernel.transfer`)
+
+```ini
+[Transfer]
+MinVersion=1.0.0
+ProtectVersion=2.1.0
+Verify=false
+InstancesMax=2
+Features=devel
+
+[Source]
+Type=url-file
+Path=https://example.com/releases/
+MatchPattern=component_@v.raw.xz
+MatchPattern=component_@v.raw.gz
+MatchPattern=component_@v.raw
+
+[Target]
+Type=regular-file
+Path=/var/lib/extensions
+MatchPattern=component_@v.raw
+CurrentSymlink=component.raw
+Mode=0644
+```
+
+### `[Transfer]` section
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `MinVersion` | string | — | Only consider versions >= this value |
+| `ProtectVersion` | string | — | Never remove this version during vacuum |
+| `Verify` | bool | `false` | Require GPG signature on SHA256SUMS |
+| `InstancesMax` | int | `2` | Maximum versions to keep; oldest removed first |
+| `Features` | string list | — | OR logic: transfer activates if *any* listed feature is enabled |
+| `RequisiteFeatures` | string list | — | AND logic: transfer activates only if *all* listed features are enabled |
+
+### `[Source]` section
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `Type` | string | Source type (currently `url-file` supported) |
+| `Path` | string | Base URL for downloads (must end with `/`) |
+| `MatchPattern` | string | Filename pattern with `@v` placeholder. Multiple entries create compression variants tried in order |
+
+### `[Target]` section
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `Type` | string | — | Target type (`regular-file`, `directory`) |
+| `Path` | string | `/var/lib/extensions` | Target directory for downloaded files |
+| `MatchPattern` | string | — | Filename pattern with `@v` for installed files |
+| `CurrentSymlink` | string | — | Symlink name pointing to the active version |
+| `Mode` | uint32 | `0644` | File permissions |
+| `ReadOnly` | bool | `false` | Whether target should be read-only |
+
+### Multiple `MatchPattern` entries
+
+Both `[Source]` and `[Target]` support multiple `MatchPattern` lines. The first is the primary pattern; additional entries are compression variants. During download, patterns are tried in order to find a matching file in the manifest.
+
+## Pattern Placeholders
+
+The `@v` placeholder is required in every `MatchPattern`. Additional placeholders are available:
+
+| Placeholder | Captures | Description |
+|-------------|----------|-------------|
+| `@v` | `[a-zA-Z0-9._+:~-]+` | Version string (required) |
+| `@u` | `[a-fA-F0-9-]+` | UUID |
+| `@f` | `[0-9]+` | Flags |
+| `@a` | `[01]` | GPT NoAuto flag |
+| `@g` | `[01]` | GrowFileSystem flag |
+| `@r` | `[01]` | Read-only flag |
+| `@t` | `[0-9]+` | Modification time |
+| `@m` | `[0-7]+` | File mode |
+| `@s` | `[0-9]+` | File size |
+| `@d` | `[0-9]+` | Tries done |
+| `@l` | `[0-9]+` | Tries left |
+| `@h` | `[a-fA-F0-9]+` | SHA256 hash |
+
+## Systemd Specifiers
+
+String values in transfer files support systemd-style `%` specifiers, expanded at parse time:
+
+| Specifier | Source | Description |
+|-----------|--------|-------------|
+| `%A` | `IMAGE_VERSION` env | Image version |
+| `%a` | Go `GOARCH` → systemd | Architecture (e.g., `x86-64`, `arm64`) |
+| `%B` | `BUILD_ID` env | Build ID |
+| `%b` | `/proc/sys/kernel/random/boot_id` | Boot ID |
+| `%H` | `os.Hostname()` | Full hostname |
+| `%l` | `os.Hostname()` | Short hostname (before first `.`) |
+| `%M` | `IMAGE_ID` env | Image ID |
+| `%m` | `/etc/machine-id` | Machine ID |
+| `%o` | `/etc/os-release` `ID=` | OS ID |
+| `%T` | — | `/tmp` |
+| `%V` | — | `/var/tmp` |
+| `%v` | `/proc/sys/kernel/osrelease` | Kernel version |
+| `%w` | `/etc/os-release` `VERSION_ID=` | OS version ID |
+| `%W` | `/etc/os-release` `VARIANT_ID=` | OS variant ID |
+| `%%` | — | Literal `%` |
+
+## Version Comparison
+
+Versions extracted via `@v` are compared using `hashicorp/go-version` (semantic versioning). If a version string cannot be parsed as semver, string comparison is used as fallback. Versions are sorted descending (newest first) when selecting which version to install.

--- a/yeti/sdk-api.md
+++ b/yeti/sdk-api.md
@@ -1,0 +1,189 @@
+# SDK API Reference
+
+The `updex` package (`github.com/frostyard/updex/updex`) is the primary public API. All operations go through the `Client` struct.
+
+## Client
+
+```go
+type Client struct { /* unexported fields */ }
+
+type ClientConfig struct {
+    Definitions  string              // Custom config file path (overrides search paths)
+    Verify       bool                // Enable GPG signature verification
+    Verbose      bool                // Enable debug output
+    Progress     reporter.Reporter   // Progress reporter (optional)
+    SysextRunner sysext.SysextRunner // Mock runner for tests (optional)
+}
+
+func NewClient(cfg ClientConfig) *Client
+```
+
+If `SysextRunner` is provided, `NewClient` calls `sysext.SetRunner()` to inject it globally.
+
+## Methods
+
+### Features
+
+```go
+func (c *Client) Features(ctx context.Context) ([]FeatureInfo, error)
+```
+
+Lists all configured features with their enabled/masked status and associated transfers.
+
+### EnableFeature / DisableFeature
+
+```go
+func (c *Client) EnableFeature(ctx context.Context, name string, opts EnableFeatureOptions) (*FeatureActionResult, error)
+func (c *Client) DisableFeature(ctx context.Context, name string, opts DisableFeatureOptions) (*FeatureActionResult, error)
+```
+
+Enable creates a drop-in file setting `Enabled=true`. Disable creates one setting `Enabled=false`.
+
+**EnableFeatureOptions:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `Now` | `bool` | Download extensions immediately after enabling |
+| `DryRun` | `bool` | Preview without modifying filesystem |
+| `NoRefresh` | `bool` | Skip `systemd-sysext refresh` |
+
+**DisableFeatureOptions:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `Now` | `bool` | Unmerge and remove files immediately |
+| `Remove` | `bool` | Deprecated alias for `Now` |
+| `Force` | `bool` | Allow removal of currently merged extensions |
+| `DryRun` | `bool` | Preview without modifying filesystem |
+| `NoRefresh` | `bool` | Skip `systemd-sysext refresh` |
+
+### UpdateFeatures
+
+```go
+func (c *Client) UpdateFeatures(ctx context.Context, opts UpdateFeaturesOptions) ([]UpdateFeaturesResult, error)
+```
+
+Downloads and installs the newest available version for each enabled feature's transfers. Returns per-feature results with per-component status.
+
+**UpdateFeaturesOptions:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `NoRefresh` | `bool` | Skip `systemd-sysext refresh` after updates |
+| `NoVacuum` | `bool` | Skip removing old versions |
+
+### CheckFeatures
+
+```go
+func (c *Client) CheckFeatures(ctx context.Context, opts CheckFeaturesOptions) ([]CheckFeaturesResult, error)
+```
+
+Checks for available updates without downloading. `CheckFeaturesOptions` is currently empty.
+
+## Result Types
+
+### FeatureInfo
+
+```go
+type FeatureInfo struct {
+    Name          string
+    Description   string
+    Documentation string
+    Enabled       bool
+    Masked        bool
+    Source        string   // Path to .feature file
+    Transfers     []string // Associated transfer component names
+}
+```
+
+### FeatureActionResult
+
+```go
+type FeatureActionResult struct {
+    Feature           string
+    Action            string   // "enable" or "disable"
+    Success           bool
+    DropIn            string   // Path to created drop-in file
+    Error             string
+    NextActionMessage string   // User guidance (e.g., "run update to download")
+    RemovedFiles      []string
+    DownloadedFiles   []string
+    DryRun            bool
+    Unmerged          bool
+}
+```
+
+### UpdateFeaturesResult / UpdateResult
+
+```go
+type UpdateFeaturesResult struct {
+    Feature string
+    Results []UpdateResult
+}
+
+type UpdateResult struct {
+    Component         string
+    Version           string
+    Downloaded        bool
+    Installed         bool
+    Error             string
+    NextActionMessage string
+}
+```
+
+### CheckFeaturesResult / CheckResult
+
+```go
+type CheckFeaturesResult struct {
+    Feature string
+    Results []CheckResult
+}
+
+type CheckResult struct {
+    Component       string
+    CurrentVersion  string
+    NewestVersion   string
+    UpdateAvailable bool
+}
+```
+
+## Supporting Packages
+
+### `config`
+
+- `LoadFeatures(customPath string) ([]*Feature, error)` — Load all `.feature` files
+- `LoadTransfers(customPath string) ([]*Transfer, error)` — Load all `.transfer` files
+- `FilterTransfersByFeatures(transfers []*Transfer, features []*Feature) []*Transfer` — Filter transfers to those matching enabled features
+- `GetTransfersForFeature(transfers []*Transfer, featureName string) []*Transfer` — Get transfers for a specific feature
+- `GetEnabledFeatureNames(features []*Feature) []string`
+- `IsFeatureEnabled(features []*Feature, name string) bool`
+
+### `manifest`
+
+- `Fetch(ctx context.Context, baseURL string, verify bool) (*Manifest, error)` — Fetch and parse `SHA256SUMS` from URL
+- `VerifyHash(filePath string, expectedHash string) error` — Verify a file's SHA256
+- `VerifyHashReader(r io.Reader, expectedHash string) *HashVerifyReader` — Streaming hash verification
+- `SetKeyringPaths(paths []string)` — Override GPG keyring locations
+
+### `download`
+
+- `Download(ctx context.Context, url, targetPath, expectedHash string, mode uint32) error` — Download with hash verification and auto-decompression
+
+### `version`
+
+- `ParsePattern(pattern string) (*Pattern, error)` — Parse `@v`-style patterns
+- `ExtractVersionMulti(filename string, patternStrs []string) (version, matchedPattern string, ok bool)` — Try multiple patterns
+- `Compare(v1, v2 string) int` — Semver comparison (-1, 0, 1)
+- `Sort(versions []string)` — Sort descending (newest first)
+
+### `sysext`
+
+- `Refresh() / Merge() / Unmerge()` — `systemd-sysext` commands
+- `SetRunner(r SysextRunner) func()` — Inject mock runner (returns cleanup)
+- `GetInstalledVersions(t *config.Transfer) ([]string, string, error)` — List installed + current version
+- `UpdateSymlink(targetDir, symlinkName, targetFile string) error`
+- `LinkToSysext(t *config.Transfer) / UnlinkFromSysext(t *config.Transfer)` — Manage `/var/lib/extensions` symlinks
+- `Vacuum(t *config.Transfer) / VacuumWithDetails(t *config.Transfer)` — Clean old versions
+
+### `systemd`
+
+- `GenerateTimer(cfg *TimerConfig) string` — Generate systemd timer unit content
+- `GenerateService(cfg *ServiceConfig) string` — Generate systemd service unit content
+- `Manager.Install(timer, service) / Remove(name) / Exists(name)` — Unit lifecycle


### PR DESCRIPTION
## Summary

Add comprehensive documentation for the updex project covering architecture, configuration, and SDK API. These docs provide a single reference for developers integrating with the SDK or operating the CLI, complementing the existing CLAUDE.md developer guide.

## Changes

- Added `yeti/OVERVIEW.md` — project overview covering architecture, package layout, dependency flow, key patterns, configuration, data flow, and CLI command reference
- Added `yeti/config-reference.md` — detailed configuration reference for `.feature` and `.transfer` INI files, pattern placeholders, systemd specifiers, and version comparison behavior
- Added `yeti/sdk-api.md` — SDK API reference documenting the `Client` struct, all public methods, option/result types, and supporting package APIs (`config`, `manifest`, `download`, `version`, `sysext`, `systemd`)