### PR TITLE
docs: update documentation for updex

### DIFF
--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -106,7 +106,7 @@ When enabled, fetches `SHA256SUMS.gpg` (detached signature) and verifies against
 1. `/etc/systemd/import-pubring.gpg`
 2. `/usr/lib/systemd/import-pubring.gpg`
 
-Uses `golang.org/x/crypto/openpgp` (deprecated; migration to ProtonMail/go-crypto planned).
+Uses `github.com/ProtonMail/go-crypto/openpgp` for signature verification. Supports both binary and armored keyring formats.
 
 ### Systemd specifiers
 
@@ -119,7 +119,7 @@ Transfer file values support systemd-style `%` specifiers. See [Configuration Re
 1. Load all `.feature` and `.transfer` files from search paths
 2. Filter transfers to those matching enabled features
 3. For each transfer:
-   - Fetch `SHA256SUMS` manifest from source URL (+ GPG verify if configured)
+   - Fetch `SHA256SUMS` manifest from source URL (+ GPG verify if configured); the manifest is retained and reused for file lookup, avoiding a redundant HTTP request
    - Extract available versions using pattern matching (`@v` placeholder)
    - Select newest version via semver comparison
    - Skip if already installed (check target directory)
@@ -173,4 +173,4 @@ Global flags:
 | `gopkg.in/ini.v1` | INI file parsing |
 | `github.com/ulikunitz/xz` | XZ decompression |
 | `github.com/klauspost/compress` | ZSTD decompression |
-| `golang.org/x/crypto/openpgp` | GPG signature verification |
+| `github.com/ProtonMail/go-crypto` | GPG signature verification (openpgp) |

--- a/yeti/config-reference.md
+++ b/yeti/config-reference.md
@@ -65,9 +65,7 @@ Features=devel
 [Source]
 Type=url-file
 Path=https://example.com/releases/
-MatchPattern=component_@v.raw.xz
-MatchPattern=component_@v.raw.gz
-MatchPattern=component_@v.raw
+MatchPattern=component_@v.raw.xz component_@v.raw.gz component_@v.raw
 
 [Target]
 Type=regular-file
@@ -94,7 +92,7 @@ Mode=0644
 |-----|------|-------------|
 | `Type` | string | Source type (currently `url-file` supported) |
 | `Path` | string | Base URL for downloads (must end with `/`) |
-| `MatchPattern` | string | Filename pattern with `@v` placeholder. Multiple entries create compression variants tried in order |
+| `MatchPattern` | string | Filename pattern(s) with `@v` placeholder. Space-separated values define compression variants tried in order |
 
 ### `[Target]` section
 
@@ -107,9 +105,15 @@ Mode=0644
 | `Mode` | uint32 | `0644` | File permissions |
 | `ReadOnly` | bool | `false` | Whether target should be read-only |
 
-### Multiple `MatchPattern` entries
+### Multiple `MatchPattern` values
 
-Both `[Source]` and `[Target]` support multiple `MatchPattern` lines. The first is the primary pattern; additional entries are compression variants. During download, patterns are tried in order to find a matching file in the manifest.
+`MatchPattern` accepts space-separated patterns on a single line. The first is the primary pattern; additional entries are compression variants. During download, patterns are tried in order to find a matching file in the manifest.
+
+```ini
+MatchPattern=component_@v.raw.xz component_@v.raw.gz component_@v.raw
+```
+
+Specifiers (`%a`, `%v`, `%w`, etc.) are expanded on each pattern after splitting.
 
 ## Pattern Placeholders
 
@@ -136,13 +140,13 @@ String values in transfer files support systemd-style `%` specifiers, expanded a
 
 | Specifier | Source | Description |
 |-----------|--------|-------------|
-| `%A` | `IMAGE_VERSION` env | Image version |
+| `%A` | `/etc/os-release` `IMAGE_VERSION=` | Image version |
 | `%a` | Go `GOARCH` → systemd | Architecture (e.g., `x86-64`, `arm64`) |
-| `%B` | `BUILD_ID` env | Build ID |
+| `%B` | `/etc/os-release` `BUILD_ID=` | Build ID |
 | `%b` | `/proc/sys/kernel/random/boot_id` | Boot ID |
 | `%H` | `os.Hostname()` | Full hostname |
 | `%l` | `os.Hostname()` | Short hostname (before first `.`) |
-| `%M` | `IMAGE_ID` env | Image ID |
+| `%M` | `/etc/os-release` `IMAGE_ID=` | Image ID |
 | `%m` | `/etc/machine-id` | Machine ID |
 | `%o` | `/etc/os-release` `ID=` | OS ID |
 | `%T` | — | `/tmp` |

--- a/yeti/sdk-api.md
+++ b/yeti/sdk-api.md
@@ -178,12 +178,18 @@ type CheckResult struct {
 - `Refresh() / Merge() / Unmerge()` — `systemd-sysext` commands
 - `SetRunner(r SysextRunner) func()` — Inject mock runner (returns cleanup)
 - `GetInstalledVersions(t *config.Transfer) ([]string, string, error)` — List installed + current version
+- `GetActiveVersion(t *config.Transfer) (string, error)` — Get version currently active in systemd-sysext (checks current symlink and `/run/extensions`)
 - `UpdateSymlink(targetDir, symlinkName, targetFile string) error`
 - `LinkToSysext(t *config.Transfer) / UnlinkFromSysext(t *config.Transfer)` — Manage `/var/lib/extensions` symlinks
 - `Vacuum(t *config.Transfer) / VacuumWithDetails(t *config.Transfer)` — Clean old versions
+- `RemoveAllVersions(t *config.Transfer) ([]string, error)` — Remove all versions and current symlink for a component
+- `GetExtensionName(filename string) string` — Extract extension name from filename (strips version and compression suffixes)
+- `SysextDir` — Constant: `/var/lib/extensions`
 
 ### `systemd`
 
+- `NewManager() *Manager` — Create manager with default paths (`/etc/systemd/system`)
+- `NewTestManager(unitPath string, runner SystemctlRunner) *Manager` — Create manager with custom paths and runner for testing
 - `GenerateTimer(cfg *TimerConfig) string` — Generate systemd timer unit content
 - `GenerateService(cfg *ServiceConfig) string` — Generate systemd service unit content
 - `Manager.Install(timer, service) / Remove(name) / Exists(name)` — Unit lifecycle


### PR DESCRIPTION
## Summary

Updates project documentation to reflect recent code changes: the migration from the deprecated `golang.org/x/crypto/openpgp` package to `github.com/ProtonMail/go-crypto`, the elimination of redundant manifest HTTP requests in the update flow, and newly exported API surfaces in the `sysext` and `systemd` packages.

## Changes

- Updated GPG verification references from deprecated `golang.org/x/crypto/openpgp` to `github.com/ProtonMail/go-crypto/openpgp`, noting support for armored keyrings
- Documented that the manifest is now fetched once and reused, avoiding a redundant HTTP request during updates
- Changed `MatchPattern` documentation from multiple INI lines to space-separated values on a single line, matching current parser behavior
- Corrected specifier sources for `%A`, `%B`, and `%M` — these read from `/etc/os-release` fields, not environment variables
- Added newly exported `sysext` functions to SDK API reference: `GetActiveVersion`, `RemoveAllVersions`, `GetExtensionName`, and `SysextDir` constant
- Added `systemd.NewManager()` and `NewTestManager()` constructors to SDK API reference