### PR TITLE
docs: update documentation for updex

### DIFF
--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -18,9 +18,10 @@ cmd/updex/client.go             CLI → SDK client factory
 
 updex/                          Public SDK (Client + methods)
   updex.go                      Client struct, NewClient()
-  features.go                   Features(), EnableFeature(), DisableFeature()
-  install.go                    UpdateFeatures(), installTransfer()
-  list.go                       CheckFeatures(), getAvailableVersions()
+  features.go                   Features(), EnableFeature(), DisableFeature(),
+                                UpdateFeatures(), CheckFeatures()
+  install.go                    installTransfer() helper (unexported)
+  list.go                       getAvailableVersions() helper (unexported)
   options.go                    Option structs for all operations
   results.go                    Result structs for all operations
 
@@ -55,14 +56,14 @@ CLI (cmd/daemon.go) → systemd (direct, bypasses SDK)
 ### Testing patterns
 
 - Mock interfaces for system commands: `sysext.SysextRunner`, `systemd.SystemctlRunner`
-- Global runner injection via `SetRunner()` returning cleanup function
-- `ClientConfig.SysextRunner` field for injecting mocks into the SDK client
+- `ClientConfig.SysextRunner` field for injecting mocks into the SDK client — `NewClient` stores the runner directly on the `Client` struct (does not mutate global state)
+- Package-level `SetRunner()` returning cleanup function still exists on `sysext` and `systemd` packages for non-SDK test code
 - `internal/testutil.NewTestServer()` creates `httptest.Server` with configurable manifests and file content
 - `t.TempDir()` for filesystem operations, `t.Context()` for context
 
 ### CLI output
 
-- Text tables by default, JSON with `--json` flag via `common.OutputJSON()`
+- Text tables by default, JSON with `--json` flag — both `--json` and `--dry-run` are provided by the `github.com/frostyard/clix` package, not defined in this repo
 - Operations requiring filesystem changes call `requireRoot()` to enforce root access
 
 ### Public API (Issue #13)
@@ -123,7 +124,7 @@ Transfer file values support systemd-style `%` specifiers. See [Configuration Re
    - Extract available versions using pattern matching (`@v` placeholder)
    - Select newest version via semver comparison
    - Skip if already installed (check target directory)
-   - Download file, verify SHA256 hash during transfer
+   - Download file, verify SHA256 hash of compressed bytes during transfer
    - Decompress if needed (xz, gz, zstd — detected from filename)
    - Atomically rename to final path, update `CurrentSymlink`
    - Create symlink in `/var/lib/extensions/` pointing to extension
@@ -132,8 +133,8 @@ Transfer file values support systemd-style `%` specifiers. See [Configuration Re
 
 ### Enable/disable feature
 
-- **Enable**: Creates a drop-in file in `/etc/sysupdate.d/<name>.feature.d/` setting `Enabled=true`. With `--now`, also downloads extensions immediately.
-- **Disable**: Creates drop-in setting `Enabled=false`. With `--now`, also unmerges and removes extension files. `--force` allows removal of currently merged extensions.
+- **Enable**: Creates drop-in at `/etc/sysupdate.d/<name>.feature.d/00-updex.conf` setting `Enabled=true`. With `--now`, also downloads extensions immediately.
+- **Disable**: Creates drop-in setting `Enabled=false`. With `--now`, calls `Unmerge()`, removes symlinks from `/var/lib/extensions/`, and deletes all versioned files. `--force` required if extensions are currently active/merged.
 
 ## CLI Commands
 

--- a/yeti/config-reference.md
+++ b/yeti/config-reference.md
@@ -31,7 +31,7 @@ Enabled=true
 |-----|------|-------------|
 | `Description` | string | Human-readable description |
 | `Documentation` | string | URL to documentation |
-| `AppStream` | string | AppStream catalog XML URL |
+| `AppStream` | string | AppStream catalog XML URL (parsed by `config` package but not surfaced in the SDK's `FeatureInfo` result) |
 | `Enabled` | bool | Whether the feature is active (`true`/`false`) |
 
 ### Masked features
@@ -114,6 +114,8 @@ MatchPattern=component_@v.raw.xz component_@v.raw.gz component_@v.raw
 ```
 
 Specifiers (`%a`, `%v`, `%w`, etc.) are expanded on each pattern after splitting.
+
+In Go code, the `Transfer` struct stores both `MatchPattern` (first pattern, for backward compatibility) and `MatchPatterns` (all patterns). The `Patterns()` method on `SourceSection`/`TargetSection` returns the canonical list.
 
 ## Pattern Placeholders
 

--- a/yeti/sdk-api.md
+++ b/yeti/sdk-api.md
@@ -18,7 +18,7 @@ type ClientConfig struct {
 func NewClient(cfg ClientConfig) *Client
 ```
 
-If `SysextRunner` is provided, `NewClient` calls `sysext.SetRunner()` to inject it globally.
+`NewClient` stores the provided `SysextRunner` directly on the `Client` struct. If `SysextRunner` is nil (including typed nil interfaces, checked via `reflect`), it defaults to `&sysext.DefaultRunner{}`. If `Progress` is nil, it defaults to `reporter.NoopReporter{}`. The client does not mutate global package state.
 
 ## Methods
 
@@ -164,19 +164,28 @@ type CheckResult struct {
 
 ### `download`
 
-- `Download(ctx context.Context, url, targetPath, expectedHash string, mode uint32) error` — Download with hash verification and auto-decompression
+- `Download(ctx context.Context, url, targetPath, expectedHash string, mode uint32) error` — Download with hash verification (on compressed bytes) and auto-decompression. Uses atomic rename (falls back to copy on cross-device). HTTP timeout: 10 minutes. Default mode: `0644` if `mode == 0`
+- `DecompressReader(r io.Reader, compressionType string) (io.ReadCloser, error)` — Returns a decompressing reader for `"xz"`, `"gz"`, `"zstd"`, or passthrough for `""`
 
 ### `version`
 
-- `ParsePattern(pattern string) (*Pattern, error)` — Parse `@v`-style patterns
-- `ExtractVersionMulti(filename string, patternStrs []string) (version, matchedPattern string, ok bool)` — Try multiple patterns
-- `Compare(v1, v2 string) int` — Semver comparison (-1, 0, 1)
+- `ParsePattern(pattern string) (*Pattern, error)` — Parse `@v`-style patterns. Returns `ErrEmptyPattern` or `ErrMissingVersionPlaceholder` on invalid input
+- `ParsePatterns(patternStrs []string) ([]*Pattern, error)` — Parse multiple patterns; skips invalid ones, returns first error
+- `ExtractVersionParsed(filename string, patterns []*Pattern) (version, matchedPattern string, ok bool)` — Try pre-parsed patterns against a filename (preferred for loops)
+- `ExtractVersionMulti(filename string, patternStrs []string) (version, matchedPattern string, ok bool)` — **Deprecated**: recompiles regexes on every call; use `ParsePatterns` + `ExtractVersionParsed` instead
+- `Compare(v1, v2 string) int` — Semver comparison (-1, 0, 1); normalizes by stripping `v`/`V` prefix; falls back to string comparison
 - `Sort(versions []string)` — Sort descending (newest first)
+
+**`Pattern` methods:**
+- `ExtractVersion(filename string) (string, bool)` — Extract version from a single filename
+- `Matches(filename string) bool` — Test if filename matches the pattern
+- `BuildFilename(version string) string` — Construct filename from a version string
+- `Raw() string` — Return the original pattern string
 
 ### `sysext`
 
-- `Refresh() / Merge() / Unmerge()` — `systemd-sysext` commands
-- `SetRunner(r SysextRunner) func()` — Inject mock runner (returns cleanup)
+- `Refresh() / Merge() / Unmerge()` — Package-level convenience functions delegating to a global runner
+- `SetRunner(r SysextRunner) func()` — Inject mock runner globally (returns cleanup). Used by non-SDK test code; SDK tests should use `ClientConfig.SysextRunner` instead
 - `GetInstalledVersions(t *config.Transfer) ([]string, string, error)` — List installed + current version
 - `GetActiveVersion(t *config.Transfer) (string, error)` — Get version currently active in systemd-sysext (checks current symlink and `/run/extensions`)
 - `UpdateSymlink(targetDir, symlinkName, targetFile string) error`


### PR DESCRIPTION
## Summary

Update project documentation to reflect recent refactoring changes: `NewClient` no longer mutates global sysext runner state (PR #58), `ExtractVersionMulti` now caches parsed patterns (PR #57), and helper methods were extracted for pattern matching fallback (PR #56). Also improves accuracy of existing documentation around disable behavior, hash verification, CLI flag provenance, and multi-pattern configuration.

## Changes

- Updated SDK overview to reflect that `UpdateFeatures()` and `CheckFeatures()` now live in `features.go`, with `install.go` and `list.go` containing only unexported helpers
- Documented that `NewClient` stores the sysext runner directly on the `Client` struct instead of mutating global state
- Added documentation for `ParsePatterns`, `ExtractVersionParsed`, and `Pattern` methods (`ExtractVersion`, `Matches`, `BuildFilename`, `Raw`)
- Marked `ExtractVersionMulti` as deprecated in favor of `ParsePatterns` + `ExtractVersionParsed`
- Clarified that `--json` and `--dry-run` flags come from the `clix` package, not this repo
- Corrected enable/disable docs: specified drop-in path (`00-updex.conf`), clarified disable calls `Unmerge()` and removes symlinks/files
- Noted that SHA256 verification happens on compressed bytes, not decompressed content
- Added `DecompressReader` to the download package API reference
- Documented `MatchPattern` vs `MatchPatterns` fields and the `Patterns()` method in config reference
- Noted that `AppStream` is parsed but not surfaced in the SDK's `FeatureInfo` result