### PR TITLE
docs: update documentation for updex

### DIFF
--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -20,7 +20,8 @@ updex/                          Public SDK (Client + methods)
   updex.go                      Client struct, NewClient()
   features.go                   Features(), EnableFeature(), DisableFeature(),
                                 UpdateFeatures(), CheckFeatures()
-  install.go                    installTransfer() helper (unexported)
+  install.go                    installTransfer() — complete install pipeline
+                                (download, symlink, sysext link, refresh, vacuum)
   list.go                       getAvailableVersions() helper (unexported)
   options.go                    Option structs for all operations
   results.go                    Result structs for all operations
@@ -129,7 +130,7 @@ Transfer file values support systemd-style `%` specifiers. See [Configuration Re
    - Atomically rename to final path, update `CurrentSymlink`
    - Create symlink in `/var/lib/extensions/` pointing to extension
    - Vacuum old versions per `InstancesMax`
-4. Call `systemd-sysext refresh` to reload all extensions (unless `--no-refresh`)
+4. Call `systemd-sysext refresh` to reload all extensions (unless `--no-refresh`). Callers batch this — `installTransfer` is called with `NoRefresh: true` per-component, and a single refresh runs at the end
 
 ### Enable/disable feature
 

--- a/yeti/sdk-api.md
+++ b/yeti/sdk-api.md
@@ -37,7 +37,7 @@ func (c *Client) EnableFeature(ctx context.Context, name string, opts EnableFeat
 func (c *Client) DisableFeature(ctx context.Context, name string, opts DisableFeatureOptions) (*FeatureActionResult, error)
 ```
 
-Enable creates a drop-in file setting `Enabled=true`. Disable creates one setting `Enabled=false`.
+Enable creates a drop-in file setting `Enabled=true`. With `Now: true`, it downloads extensions via the shared `installTransfer` pipeline. Disable creates a drop-in setting `Enabled=false`.
 
 **EnableFeatureOptions:**
 | Field | Type | Description |
@@ -61,7 +61,7 @@ Enable creates a drop-in file setting `Enabled=true`. Disable creates one settin
 func (c *Client) UpdateFeatures(ctx context.Context, opts UpdateFeaturesOptions) ([]UpdateFeaturesResult, error)
 ```
 
-Downloads and installs the newest available version for each enabled feature's transfers. Returns per-feature results with per-component status.
+Downloads and installs the newest available version for each enabled feature's transfers. Delegates per-component work to the internal `installTransfer` pipeline (which handles download, symlink, sysext linking, and vacuum). Refresh is batched — a single `systemd-sysext refresh` runs after all components are processed. Returns per-feature results with per-component status.
 
 **UpdateFeaturesOptions:**
 | Field | Type | Description |


### PR DESCRIPTION
## Summary

Update SDK and architecture documentation to reflect the consolidated `installTransfer` pipeline introduced in #59. The docs now accurately describe how download, symlink, sysext linking, refresh, and vacuum are handled through a single shared code path, and clarify the batched refresh behavior.

## Changes

- Updated `OVERVIEW.md` to expand the `install.go` description with the full install pipeline steps (download, symlink, sysext link, refresh, vacuum)
- Clarified the update flow in `OVERVIEW.md` to document that `installTransfer` is called with `NoRefresh: true` per-component, with a single batched refresh at the end
- Updated `sdk-api.md` `EnableFeature` docs to note that `Now: true` uses the shared `installTransfer` pipeline
- Updated `sdk-api.md` `UpdateFeatures` docs to describe delegation to `installTransfer` and the batched refresh behavior