### PR TITLE
refactor: Remove reflect import by using concrete nil check in NewClient

### DIFF
--- a/updex/updex.go
+++ b/updex/updex.go
@@ -17,8 +17,6 @@
 package updex
 
 import (
-	"reflect"
-
 	"github.com/frostyard/std/reporter"
 	"github.com/frostyard/updex/sysext"
 )
@@ -63,7 +61,7 @@ func NewClient(cfg ClientConfig) *Client {
 		r = reporter.NoopReporter{}
 	}
 	sr := cfg.SysextRunner
-	if sr == nil || reflect.ValueOf(sr).IsNil() {
+	if sr == nil {
 		sr = &sysext.DefaultRunner{}
 	}
 	return &Client{


### PR DESCRIPTION
In `updex/updex.go:66`, `reflect.ValueOf(sr).IsNil()` is used to check if the `SysextRunner` interface holds a nil pointer. This imports the entire `reflect` package for a single check. Since `SysextRunner` is only implemented by `*DefaultRunner` and `*MockRunner` (both pointer types), this can be replaced with a type-switch or simply documented that callers must not pass a typed nil. Alternatively, check `cfg.SysextRunner == nil` alone — a typed nil `SysextRunner` is a caller bug that should surface as a nil pointer dereference rather than being silently corrected.

---
*Automated improvement by yeti improvement-identifier*