### PR TITLE
refactor: Use errors.Join in systemd Manager.Remove instead of fmt.Errorf with %v on slice

### DIFF
--- a/systemd/manager.go
+++ b/systemd/manager.go
@@ -1,6 +1,7 @@
 package systemd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -99,10 +100,7 @@ func (m *Manager) Remove(name string) error {
 		errs = append(errs, fmt.Errorf("daemon-reload: %w", err))
 	}
 
-	if len(errs) > 0 {
-		return fmt.Errorf("errors during removal: %v", errs)
-	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // Exists checks if either timer or service file exists at UnitPath


### PR DESCRIPTION
In `systemd/manager.go:102-103`, errors are aggregated into a `[]error` slice and then formatted with `fmt.Errorf("errors during removal: %v", errs)`. This produces an unstructured string representation like `[remove timer: ... daemon-reload: ...]`. Use `errors.Join(errs...)` instead, which produces a properly formatted multi-error that callers can unwrap with `errors.Is`/`errors.As`.

---
*Automated improvement by yeti improvement-identifier*