### PR TITLE
refactor: Remove deprecated ExtractVersionMulti function

### DIFF
--- a/version/pattern.go
+++ b/version/pattern.go
@@ -99,24 +99,6 @@ func (p *Pattern) Raw() string {
 	return p.raw
 }
 
-// ExtractVersionMulti tries to extract a version from a filename using multiple patterns.
-// Returns the version and the matching pattern, or empty strings if no match.
-//
-// Deprecated: This recompiles patterns on every call. For loops, use ParsePatterns
-// to pre-parse once and then call ExtractVersionParsed.
-func ExtractVersionMulti(filename string, patternStrs []string) (version string, matchedPattern string, ok bool) {
-	for _, patternStr := range patternStrs {
-		p, err := ParsePattern(patternStr)
-		if err != nil {
-			continue
-		}
-		if v, matched := p.ExtractVersion(filename); matched {
-			return v, patternStr, true
-		}
-	}
-	return "", "", false
-}
-
 // ParsePatterns parses multiple pattern strings, skipping any that fail to parse.
 // It returns the first parse error encountered so callers can surface it when all
 // patterns fail.

--- a/version/pattern_test.go
+++ b/version/pattern_test.go
@@ -450,9 +450,9 @@ func TestPattern_FedoraSysextsStyleWithSpecifierExpansion(t *testing.T) {
 	}
 }
 
-func TestExtractVersionMulti_FedoraSysextsPattern(t *testing.T) {
-	// Test ExtractVersionMulti with fedora-sysexts pattern
-	// This test verifies that ExtractVersionMulti correctly matches and extracts versions
+func TestExtractVersionParsed_FedoraSysextsPattern(t *testing.T) {
+	// Test ExtractVersionParsed with fedora-sysexts pattern
+	// This test verifies that ExtractVersionParsed correctly matches and extracts versions
 	tests := []struct {
 		name              string
 		originalPatterns  []string // Patterns with unexpanded specifiers
@@ -495,15 +495,16 @@ func TestExtractVersionMulti_FedoraSysextsPattern(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// In real usage, patterns would be expanded first (specifiers replaced).
 			// We test with the expanded patterns and track which original pattern matched.
-			version, matched, ok := ExtractVersionMulti(tt.filename, tt.expandedPatterns)
+			patterns, _ := ParsePatterns(tt.expandedPatterns)
+			version, matched, ok := ExtractVersionParsed(tt.filename, patterns)
 
 			if ok != tt.expectOK {
-				t.Errorf("ExtractVersionMulti() ok = %v, want %v", ok, tt.expectOK)
+				t.Errorf("ExtractVersionParsed() ok = %v, want %v", ok, tt.expectOK)
 			}
 
 			if ok {
 				if version != tt.expectVersion {
-					t.Errorf("ExtractVersionMulti() version = %q, want %q", version, tt.expectVersion)
+					t.Errorf("ExtractVersionParsed() version = %q, want %q", version, tt.expectVersion)
 				}
 				// Find which original pattern corresponds to the matched expanded pattern
 				var matchedOrig string
@@ -514,7 +515,7 @@ func TestExtractVersionMulti_FedoraSysextsPattern(t *testing.T) {
 					}
 				}
 				if matchedOrig != tt.expectOrigPattern {
-					t.Errorf("ExtractVersionMulti() matched original = %q, want %q", matchedOrig, tt.expectOrigPattern)
+					t.Errorf("ExtractVersionParsed() matched original = %q, want %q", matchedOrig, tt.expectOrigPattern)
 				}
 			}
 		})

--- a/yeti/sdk-api.md
+++ b/yeti/sdk-api.md
@@ -172,7 +172,6 @@ type CheckResult struct {
 - `ParsePattern(pattern string) (*Pattern, error)` — Parse `@v`-style patterns. Returns `ErrEmptyPattern` or `ErrMissingVersionPlaceholder` on invalid input
 - `ParsePatterns(patternStrs []string) ([]*Pattern, error)` — Parse multiple patterns; skips invalid ones, returns first error
 - `ExtractVersionParsed(filename string, patterns []*Pattern) (version, matchedPattern string, ok bool)` — Try pre-parsed patterns against a filename (preferred for loops)
-- `ExtractVersionMulti(filename string, patternStrs []string) (version, matchedPattern string, ok bool)` — **Deprecated**: recompiles regexes on every call; use `ParsePatterns` + `ExtractVersionParsed` instead
 - `Compare(v1, v2 string) int` — Semver comparison (-1, 0, 1); normalizes by stripping `v`/`V` prefix; falls back to string comparison
 - `Sort(versions []string)` — Sort descending (newest first)
 


### PR DESCRIPTION
In `version/pattern.go:102-118`, `ExtractVersionMulti` is marked as deprecated in favor of `ParsePatterns` + `ExtractVersionParsed`. It is only used in its own test file (`version/pattern_test.go:498`). Since the codebase has already migrated all call sites to the new API (confirmed by PR #57), this function and its test can be removed to reduce surface area and prevent new callers from using the slow path.

---
*Automated improvement by yeti improvement-identifier*