### PR TITLE
docs: update documentation for updex

### DIFF
--- a/yeti/sdk-api.md
+++ b/yeti/sdk-api.md
@@ -18,7 +18,7 @@ type ClientConfig struct {
 func NewClient(cfg ClientConfig) *Client
 ```
 
-`NewClient` stores the provided `SysextRunner` directly on the `Client` struct. If `SysextRunner` is nil (including typed nil interfaces, checked via `reflect`), it defaults to `&sysext.DefaultRunner{}`. If `Progress` is nil, it defaults to `reporter.NoopReporter{}`. The client does not mutate global package state.
+`NewClient` stores the provided `SysextRunner` directly on the `Client` struct. If `SysextRunner` is nil, it defaults to `&sysext.DefaultRunner{}`. If `Progress` is nil, it defaults to `reporter.NoopReporter{}`. The client does not mutate global package state.
 
 ## Methods
 


### PR DESCRIPTION
## Summary

Updates the SDK API documentation to reflect the simplified nil check in `NewClient`, which no longer uses `reflect` for typed nil interface detection. This aligns the docs with the recent refactor in #62 that removed the `reflect` import.

## Changes

- Updated `NewClient` description to remove mention of typed nil interface checking via `reflect`, matching the simplified nil check now used in the implementation