### PR TITLE
refactor: Handle ParsePatterns errors in VacuumWithDetails and RemoveAllVersions

### DIFF
--- a/sysext/manager.go
+++ b/sysext/manager.go
@@ -149,7 +149,10 @@ func VacuumWithDetails(t *config.Transfer) (removed []string, kept []string, err
 		return nil, nil, fmt.Errorf("no target match patterns defined")
 	}
 
-	patterns, _ := version.ParsePatterns(patternStrs)
+	patterns, firstErr := version.ParsePatterns(patternStrs)
+	if len(patterns) == 0 {
+		return nil, nil, fmt.Errorf("invalid target pattern: %w", firstErr)
+	}
 
 	targetDir := t.Target.Path
 	if targetDir == "" {
@@ -336,7 +339,10 @@ func RemoveAllVersions(t *config.Transfer) ([]string, error) {
 		return nil, fmt.Errorf("no target match patterns defined")
 	}
 
-	patterns, _ := version.ParsePatterns(patternStrs)
+	patterns, firstErr := version.ParsePatterns(patternStrs)
+	if len(patterns) == 0 {
+		return nil, fmt.Errorf("invalid target pattern: %w", firstErr)
+	}
 
 	targetDir := t.Target.Path
 	if targetDir == "" {


### PR DESCRIPTION
In `sysext/manager.go`, both `VacuumWithDetails` (line 152) and `RemoveAllVersions` (line 339) discard the error from `version.ParsePatterns` with `patterns, _ := version.ParsePatterns(patternStrs)`. If all patterns fail to parse, `patterns` is empty and the functions silently return `nil, nil, nil` — appearing to succeed while doing nothing.

This is inconsistent with `GetInstalledVersions` (lines 22-25) and `GetActiveVersion` (lines 85-88) in the same file, which properly check `len(patterns) == 0` and return an error.

For `VacuumWithDetails`, this means old versions may silently accumulate if patterns become invalid. For `RemoveAllVersions`, a disable-with-removal operation could report success while leaving files on disk.

Fix: Add the same `len(patterns) == 0` check with error return that `GetInstalledVersions` uses.

---
*Automated improvement by yeti improvement-identifier*