### PR TITLE
refactor: Cache manifests by URL during UpdateFeatures and CheckFeatures

### DIFF
--- a/updex/features.go
+++ b/updex/features.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/frostyard/updex/config"
+	"github.com/frostyard/updex/manifest"
 	"github.com/frostyard/updex/sysext"
 	"github.com/frostyard/updex/version"
 )
@@ -144,7 +145,7 @@ func (c *Client) EnableFeature(ctx context.Context, name string, opts EnableFeat
 					result.DownloadedFiles = append(result.DownloadedFiles, transfer.Component+" (would download)")
 				} else {
 					// Use installTransfer which handles all the download logic
-					version, downloaded, err := c.installTransfer(ctx, transfer, installTransferOptions{
+					version, _, downloaded, err := c.installTransfer(ctx, transfer, installTransferOptions{
 						NoRefresh: true, // refresh is batched at the end
 					})
 					if err != nil {
@@ -380,6 +381,10 @@ func (c *Client) UpdateFeatures(ctx context.Context, opts UpdateFeaturesOptions)
 	var allResults []UpdateFeaturesResult
 	var hasErrors bool
 
+	// Cache manifests by source URL to avoid redundant HTTP requests
+	// when multiple transfers share the same source.
+	manifestCache := make(map[string]*manifest.Manifest)
+
 	for _, f := range features {
 		if !f.Enabled || f.Masked {
 			continue
@@ -401,10 +406,14 @@ func (c *Client) UpdateFeatures(ctx context.Context, opts UpdateFeaturesOptions)
 				Component: transfer.Component,
 			}
 
-			v, downloaded, err := c.installTransfer(ctx, transfer, installTransferOptions{
-				NoVacuum:  opts.NoVacuum,
-				NoRefresh: true, // refresh is batched at the end
+			v, m, downloaded, err := c.installTransfer(ctx, transfer, installTransferOptions{
+				NoVacuum:       opts.NoVacuum,
+				NoRefresh:      true, // refresh is batched at the end
+				CachedManifest: manifestCache[transfer.Source.Path],
 			})
+			if m != nil {
+				manifestCache[transfer.Source.Path] = m
+			}
 			if err != nil {
 				result.Error = err.Error()
 				c.warn("%s", result.Error)
@@ -458,6 +467,10 @@ func (c *Client) CheckFeatures(ctx context.Context, opts CheckFeaturesOptions) (
 
 	var allResults []CheckFeaturesResult
 
+	// Cache manifests by source URL to avoid redundant HTTP requests
+	// when multiple transfers share the same source.
+	manifestCache := make(map[string]*manifest.Manifest)
+
 	for _, f := range features {
 		if !f.Enabled || f.Masked {
 			continue
@@ -475,7 +488,10 @@ func (c *Client) CheckFeatures(ctx context.Context, opts CheckFeaturesOptions) (
 		for _, transfer := range featureTransfers {
 			c.msg("Checking %s/%s", f.Name, transfer.Component)
 
-			available, _, err := c.getAvailableVersions(ctx, transfer)
+			available, m, err := c.getAvailableVersions(ctx, transfer, manifestCache[transfer.Source.Path])
+			if m != nil {
+				manifestCache[transfer.Source.Path] = m
+			}
 			if err != nil {
 				c.warn("failed to get available versions: %v", err)
 				continue

--- a/updex/install.go
+++ b/updex/install.go
@@ -7,21 +7,23 @@ import (
 
 	"github.com/frostyard/updex/config"
 	"github.com/frostyard/updex/download"
+	"github.com/frostyard/updex/manifest"
 	"github.com/frostyard/updex/sysext"
 	"github.com/frostyard/updex/version"
 )
 
 // installTransfer performs the update/install logic for a single transfer.
-// It returns the version selected, whether a download occurred, and any error.
-func (c *Client) installTransfer(ctx context.Context, transfer *config.Transfer, opts installTransferOptions) (string, bool, error) {
+// It returns the version selected, the resolved manifest, whether a download occurred, and any error.
+// If opts.CachedManifest is non-nil, it is used instead of fetching the manifest over HTTP.
+func (c *Client) installTransfer(ctx context.Context, transfer *config.Transfer, opts installTransferOptions) (string, *manifest.Manifest, bool, error) {
 	// Get available versions (applies MinVersion filter)
-	available, m, err := c.getAvailableVersions(ctx, transfer)
+	available, m, err := c.getAvailableVersions(ctx, transfer, opts.CachedManifest)
 	if err != nil {
-		return "", false, fmt.Errorf("failed to get available versions: %w", err)
+		return "", nil, false, fmt.Errorf("failed to get available versions: %w", err)
 	}
 
 	if len(available) == 0 {
-		return "", false, fmt.Errorf("no versions available")
+		return "", nil, false, fmt.Errorf("no versions available")
 	}
 
 	// Sort and get newest
@@ -33,7 +35,7 @@ func (c *Client) installTransfer(ctx context.Context, transfer *config.Transfer,
 	installed, current, _ := sysext.GetInstalledVersions(transfer)
 	for _, v := range installed {
 		if v == versionToInstall && v == current {
-			return versionToInstall, false, nil
+			return versionToInstall, m, false, nil
 		}
 	}
 
@@ -52,7 +54,7 @@ func (c *Client) installTransfer(ctx context.Context, transfer *config.Transfer,
 	}
 
 	if sourceFile == "" {
-		return "", false, fmt.Errorf("no file found for version %s", versionToInstall)
+		return "", nil, false, fmt.Errorf("no file found for version %s", versionToInstall)
 	}
 
 	// Build target path using first target pattern
@@ -60,7 +62,7 @@ func (c *Client) installTransfer(ctx context.Context, transfer *config.Transfer,
 
 	targetPattern, err := version.ParsePattern(targetPatterns[0])
 	if err != nil {
-		return "", false, fmt.Errorf("invalid target pattern: %w", err)
+		return "", nil, false, fmt.Errorf("invalid target pattern: %w", err)
 	}
 
 	targetFile := targetPattern.BuildFilename(versionToInstall)
@@ -71,7 +73,7 @@ func (c *Client) installTransfer(ctx context.Context, transfer *config.Transfer,
 	c.debug("downloading %s → %s", downloadURL, targetPath)
 	err = download.Download(ctx, downloadURL, targetPath, expectedHash, transfer.Target.Mode)
 	if err != nil {
-		return "", false, fmt.Errorf("download failed: %w", err)
+		return "", nil, false, fmt.Errorf("download failed: %w", err)
 	}
 
 	// Update symlink if configured
@@ -101,5 +103,5 @@ func (c *Client) installTransfer(ctx context.Context, transfer *config.Transfer,
 		}
 	}
 
-	return versionToInstall, true, nil
+	return versionToInstall, m, true, nil
 }

--- a/updex/list.go
+++ b/updex/list.go
@@ -11,17 +11,24 @@ import (
 
 // getAvailableVersions retrieves available versions for a transfer from remote manifest.
 // It returns the fetched manifest alongside the versions so callers can reuse it
-// without a redundant HTTP request.
-func (c *Client) getAvailableVersions(ctx context.Context, transfer *config.Transfer) ([]string, *manifest.Manifest, error) {
+// without a redundant HTTP request. If cachedManifest is non-nil, it is used instead
+// of fetching the manifest over HTTP.
+func (c *Client) getAvailableVersions(ctx context.Context, transfer *config.Transfer, cachedManifest *manifest.Manifest) ([]string, *manifest.Manifest, error) {
 	if transfer.Source.Type != "url-file" {
 		return nil, nil, fmt.Errorf("unsupported source type: %s", transfer.Source.Type)
 	}
 
-	// Fetch manifest
-	c.debug("fetching manifest from %s", transfer.Source.Path)
-	m, err := manifest.Fetch(ctx, transfer.Source.Path, c.config.Verify || transfer.Transfer.Verify)
-	if err != nil {
-		return nil, nil, err
+	m := cachedManifest
+	if m == nil {
+		// Fetch manifest
+		c.debug("fetching manifest from %s", transfer.Source.Path)
+		var err error
+		m, err = manifest.Fetch(ctx, transfer.Source.Path, c.config.Verify || transfer.Transfer.Verify)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		c.debug("using cached manifest for %s", transfer.Source.Path)
 	}
 	c.debug("manifest has %d file(s)", len(m.Files))
 

--- a/updex/options.go
+++ b/updex/options.go
@@ -1,5 +1,7 @@
 package updex
 
+import "github.com/frostyard/updex/manifest"
+
 // UpdateFeaturesOptions configures the UpdateFeatures operation.
 type UpdateFeaturesOptions struct {
 	// NoRefresh skips running systemd-sysext refresh after update.
@@ -31,6 +33,9 @@ type installTransferOptions struct {
 
 	// NoRefresh skips running systemd-sysext refresh after install.
 	NoRefresh bool
+
+	// CachedManifest, if non-nil, is used instead of fetching the manifest over HTTP.
+	CachedManifest *manifest.Manifest
 }
 
 // DisableFeatureOptions configures the DisableFeature operation.


### PR DESCRIPTION
In `updex/features.go`, both `UpdateFeatures` (line 404) and `CheckFeatures` (line 478) iterate over all transfers for all enabled features, calling `installTransfer`/`getAvailableVersions` for each. Each call to `getAvailableVersions` (`updex/list.go:22`) fetches the SHA256SUMS manifest via HTTP from `transfer.Source.Path`.

When multiple transfers share the same `Source.Path` (common when a feature has multiple components hosted in the same repository), the same manifest is fetched redundantly. Each fetch is a full HTTP request with a 30-second timeout.

Fix: Add a `map[string]*manifest.Manifest` cache to the update/check loop, keyed by `transfer.Source.Path`. Pass the cached manifest into `installTransfer`/`getAvailableVersions` when available. This avoids redundant network requests and also ensures consistent version resolution across transfers from the same source.

---
*Automated improvement by yeti improvement-identifier*