### PR TITLE
docs: update documentation for updex

### DIFF
--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -121,7 +121,7 @@ Transfer file values support systemd-style `%` specifiers. See [Configuration Re
 1. Load all `.feature` and `.transfer` files from search paths
 2. Filter transfers to those matching enabled features
 3. For each transfer:
-   - Fetch `SHA256SUMS` manifest from source URL (+ GPG verify if configured); the manifest is retained and reused for file lookup, avoiding a redundant HTTP request
+   - Fetch `SHA256SUMS` manifest from source URL (+ GPG verify if configured); manifests are cached by source URL across transfers so that multiple transfers sharing the same source make only one HTTP request
    - Extract available versions using pattern matching (`@v` placeholder)
    - Select newest version via semver comparison
    - Skip if already installed (check target directory)

--- a/yeti/sdk-api.md
+++ b/yeti/sdk-api.md
@@ -61,7 +61,7 @@ Enable creates a drop-in file setting `Enabled=true`. With `Now: true`, it downl
 func (c *Client) UpdateFeatures(ctx context.Context, opts UpdateFeaturesOptions) ([]UpdateFeaturesResult, error)
 ```
 
-Downloads and installs the newest available version for each enabled feature's transfers. Delegates per-component work to the internal `installTransfer` pipeline (which handles download, symlink, sysext linking, and vacuum). Refresh is batched — a single `systemd-sysext refresh` runs after all components are processed. Returns per-feature results with per-component status.
+Downloads and installs the newest available version for each enabled feature's transfers. Delegates per-component work to the internal `installTransfer` pipeline (which handles download, symlink, sysext linking, and vacuum). Manifests are cached by source URL — transfers sharing the same source avoid redundant HTTP requests. Refresh is batched — a single `systemd-sysext refresh` runs after all components are processed. Returns per-feature results with per-component status.
 
 **UpdateFeaturesOptions:**
 | Field | Type | Description |
@@ -75,7 +75,7 @@ Downloads and installs the newest available version for each enabled feature's t
 func (c *Client) CheckFeatures(ctx context.Context, opts CheckFeaturesOptions) ([]CheckFeaturesResult, error)
 ```
 
-Checks for available updates without downloading. `CheckFeaturesOptions` is currently empty.
+Checks for available updates without downloading. Manifests are cached by source URL, same as `UpdateFeatures`. `CheckFeaturesOptions` is currently empty.
 
 ## Result Types
 


### PR DESCRIPTION
## Summary

Updated documentation to accurately reflect the manifest caching behavior introduced in #69. The previous docs described per-transfer manifest reuse, but the implementation now caches manifests by source URL across transfers, so multiple transfers sharing the same source make only one HTTP request.

## Changes

- **yeti/OVERVIEW.md**: Updated the update flow description to explain cross-transfer manifest caching by source URL instead of per-transfer manifest reuse
- **yeti/sdk-api.md**: Added manifest caching notes to `UpdateFeatures` and `CheckFeatures` API descriptions