### PR TITLE
refactor: Remove dead package-level runner and SetRunner in systemd package

### DIFF
--- a/systemd/runner.go
+++ b/systemd/runner.go
@@ -69,16 +69,6 @@ func (r *DefaultSystemctlRunner) IsEnabled(unit string) (bool, error) {
 	return true, nil
 }
 
-// runner is the package-level runner used by systemctl operations
-var runner SystemctlRunner = &DefaultSystemctlRunner{}
-
-// SetRunner sets the runner for testing (returns cleanup function)
-func SetRunner(r SystemctlRunner) func() {
-	old := runner
-	runner = r
-	return func() { runner = old }
-}
-
 // runSystemctl executes a systemctl command with the given arguments
 func runSystemctl(args ...string) error {
 	cmd := exec.Command("systemctl", args...)


### PR DESCRIPTION
In `systemd/runner.go`, the package-level `runner` variable (line 73) and `SetRunner` function (line 76) are completely unused. The `Manager` struct has its own `runner` field (set via `NewManager`/`NewTestManager`), and no code anywhere in the repo calls `systemd.SetRunner` or references the package-level `runner`. The `runSystemctl` function (line 83) is only called by `DefaultSystemctlRunner` methods. This dead code should be removed to avoid confusion with the instance-level `Manager.runner` field.

---
*Automated improvement by yeti improvement-identifier*