### PR TITLE
refactor: Handle defer inside loop in loadKeyring

### DIFF
--- a/manifest/gpg.go
+++ b/manifest/gpg.go
@@ -63,29 +63,40 @@ func verifySignature(ctx context.Context, client *http.Client, sigURL string, co
 // loadKeyring loads the GPG keyring from default paths
 func loadKeyring() (openpgp.EntityList, error) {
 	for _, path := range keyringPaths {
-		f, err := os.Open(path)
+		keyring, err := readKeyringFile(path)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue
 			}
 			return nil, err
 		}
-		defer func() { _ = f.Close() }()
-
-		keyring, err := openpgp.ReadKeyRing(f)
-		if err != nil {
-			// Try armored format
-			_, _ = f.Seek(0, 0)
-			keyring, err = openpgp.ReadArmoredKeyRing(f)
-			if err != nil {
-				return nil, fmt.Errorf("failed to read keyring from %s: %w", path, err)
-			}
-		}
 
 		return keyring, nil
 	}
 
 	return nil, fmt.Errorf("no keyring found in %v", keyringPaths)
+}
+
+// readKeyringFile reads a GPG keyring from a single file path.
+// Returns os.ErrNotExist if the file does not exist.
+func readKeyringFile(path string) (openpgp.EntityList, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	keyring, err := openpgp.ReadKeyRing(f)
+	if err != nil {
+		// Try armored format
+		_, _ = f.Seek(0, 0)
+		keyring, err = openpgp.ReadArmoredKeyRing(f)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read keyring from %s: %w", path, err)
+		}
+	}
+
+	return keyring, nil
 }
 
 // SetKeyringPaths allows overriding the default keyring search paths


### PR DESCRIPTION
In `manifest/gpg.go:73`, `defer func() { _ = f.Close() }()` is inside a `for` loop. The deferred close won't execute until `loadKeyring` returns, not at the end of each loop iteration. Currently the function returns on the first successful keyring read so only one file handle is ever open, but if the logic changes to try multiple keyrings this becomes a handle leak. Refactor to close the file explicitly before returning, or extract the body of the loop into a separate function so `defer` scopes correctly.

---
*Automated improvement by yeti improvement-identifier*