### PR TITLE
refactor: Surface ParsePatterns errors in installTransfer and getAvailableVersions

### DIFF
--- a/updex/install.go
+++ b/updex/install.go
@@ -41,7 +41,10 @@ func (c *Client) installTransfer(ctx context.Context, transfer *config.Transfer,
 
 	// Find the file for this version
 	patternStrs := transfer.Source.Patterns()
-	patterns, _ := version.ParsePatterns(patternStrs)
+	patterns, firstErr := version.ParsePatterns(patternStrs)
+	if len(patterns) == 0 && firstErr != nil {
+		return "", nil, false, fmt.Errorf("invalid source pattern: %w", firstErr)
+	}
 
 	var sourceFile string
 	var expectedHash string

--- a/updex/list.go
+++ b/updex/list.go
@@ -35,7 +35,10 @@ func (c *Client) getAvailableVersions(ctx context.Context, transfer *config.Tran
 	// Extract versions from filenames using all patterns
 	patternStrs := transfer.Source.Patterns()
 	c.debug("matching against pattern(s): %v", patternStrs)
-	patterns, _ := version.ParsePatterns(patternStrs)
+	patterns, firstErr := version.ParsePatterns(patternStrs)
+	if len(patterns) == 0 && firstErr != nil {
+		return nil, nil, fmt.Errorf("invalid source pattern: %w", firstErr)
+	}
 
 	versionSet := make(map[string]bool)
 	for filename := range m.Files {


### PR DESCRIPTION
In `updex/install.go:44` and `updex/list.go:38`, the error from `version.ParsePatterns()` is silently discarded with `patterns, _ := version.ParsePatterns(patternStrs)`. If all source patterns are invalid, `patterns` will be empty and the code will produce a confusing downstream error ("no file found for version X" or silently find zero versions) instead of reporting the actual problem. The error should be checked: if `len(patterns) == 0` and there was an error, return it wrapped with context (matching the pattern already used in `sysext/manager.go`).

---
*Automated improvement by yeti improvement-identifier*