### PR TITLE
fix: resolve #71 — nightly snapshot is failing

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -125,6 +125,7 @@ nfpms:
       - apk
 
 release:
+  mode: replace
   footer: |
     **Full Changelog**: https://github.com/bketelsen/{{ .ProjectName }}/compare/{{ .PreviousTag }}...{{ .Tag }}
 


### PR DESCRIPTION
## Summary

The nightly snapshot build was failing because GoReleaser's default behavior doesn't handle pre-existing releases. Adding `mode: replace` to the release configuration tells GoReleaser to replace an existing release if one already exists for the same tag, which is necessary for recurring nightly builds that reuse the same tag.

## Changes

- Added `mode: replace` to the `release` section in `.goreleaser.yaml` so that nightly builds can overwrite a previous release with the same tag

Closes #71