### PR TITLE
docs: update documentation for updex

### DIFF
--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -58,7 +58,7 @@ CLI (cmd/daemon.go) → systemd (direct, bypasses SDK)
 
 - Mock interfaces for system commands: `sysext.SysextRunner`, `systemd.SystemctlRunner`
 - `ClientConfig.SysextRunner` field for injecting mocks into the SDK client — `NewClient` stores the runner directly on the `Client` struct (does not mutate global state)
-- Package-level `SetRunner()` returning cleanup function still exists on `sysext` and `systemd` packages for non-SDK test code
+- Package-level `SetRunner()` returning cleanup function exists on the `sysext` package for non-SDK test code
 - `internal/testutil.NewTestServer()` creates `httptest.Server` with configurable manifests and file content
 - `t.TempDir()` for filesystem operations, `t.Context()` for context
 


### PR DESCRIPTION
## Summary

Updated the project overview documentation to accurately reflect the current state of the codebase. The `SetRunner()` helper function was previously documented as existing in both the `sysext` and `systemd` packages, but it has been removed from the `systemd` package, so the docs now reflect that it only exists in `sysext`.

## Changes

- Updated `yeti/OVERVIEW.md` testing section to remove the incorrect reference to `systemd.SetRunner()`, which no longer exists in the codebase
- Clarified that the package-level `SetRunner()` pattern is scoped to the `sysext` package only