### PR TITLE
refactor: Remove hardcoded progress bar from download package

### DIFF
--- a/cmd/updex/client.go
+++ b/cmd/updex/client.go
@@ -1,16 +1,44 @@
 package updex
 
 import (
+	"fmt"
+	"io"
+	"time"
+
 	"github.com/frostyard/clix"
 	"github.com/frostyard/updex/updex"
+	"github.com/schollz/progressbar/v3"
 )
 
 // newClient creates a new updex client with the appropriate progress reporter.
 func newClient() *updex.Client {
 	return updex.NewClient(updex.ClientConfig{
-		Definitions: definitions,
-		Verify:      verify,
-		Verbose:     clix.Verbose,
-		Progress:    clix.NewReporter(),
+		Definitions:        definitions,
+		Verify:             verify,
+		Verbose:            clix.Verbose,
+		Progress:           clix.NewReporter(),
+		OnDownloadProgress: newProgressBar,
 	})
+}
+
+// newProgressBar creates a terminal progress bar for download tracking.
+func newProgressBar(contentLength int64) io.Writer {
+	return progressbar.NewOptions64(
+		contentLength,
+		progressbar.OptionSetDescription("Downloading"),
+		progressbar.OptionShowBytes(true),
+		progressbar.OptionSetWidth(40),
+		progressbar.OptionThrottle(100*time.Millisecond),
+		progressbar.OptionShowCount(),
+		progressbar.OptionOnCompletion(func() { fmt.Println() }),
+		progressbar.OptionSetPredictTime(true),
+		progressbar.OptionFullWidth(),
+		progressbar.OptionSetTheme(progressbar.Theme{
+			Saucer:        "=",
+			SaucerHead:    ">",
+			SaucerPadding: " ",
+			BarStart:      "[",
+			BarEnd:        "]",
+		}),
+	)
 }

--- a/download/download.go
+++ b/download/download.go
@@ -10,13 +10,18 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/schollz/progressbar/v3"
 )
 
+// ProgressFunc is called before downloading begins with the response content
+// length (-1 if unknown). It returns an io.Writer that will receive downloaded
+// bytes for progress tracking. Return nil to disable progress tracking.
+type ProgressFunc func(contentLength int64) io.Writer
+
 // Download fetches a file from URL, verifies its hash, decompresses if needed,
-// and atomically writes it to the target path
-func Download(ctx context.Context, url, targetPath, expectedHash string, mode uint32) error {
+// and atomically writes it to the target path. If onProgress is non-nil, it is
+// called with the content length after the HTTP response is received, and the
+// returned writer receives downloaded bytes for progress tracking.
+func Download(ctx context.Context, url, targetPath, expectedHash string, mode uint32, onProgress ProgressFunc) error {
 	// Create target directory if needed
 	targetDir := filepath.Dir(targetPath)
 	if err := os.MkdirAll(targetDir, 0755); err != nil {
@@ -54,32 +59,18 @@ func Download(ctx context.Context, url, targetPath, expectedHash string, mode ui
 		return fmt.Errorf("download failed with status: %s", resp.Status)
 	}
 
-	// Set up progress bar
-	bar := progressbar.NewOptions64(
-		resp.ContentLength,
-		progressbar.OptionSetDescription("Downloading"),
-		progressbar.OptionShowBytes(true),
-		progressbar.OptionSetWidth(40),
-		progressbar.OptionThrottle(100*time.Millisecond),
-		progressbar.OptionShowCount(),
-		progressbar.OptionOnCompletion(func() { fmt.Println() }),
-		progressbar.OptionSetPredictTime(true),
-		progressbar.OptionFullWidth(),
-		progressbar.OptionSetTheme(progressbar.Theme{
-			Saucer:        "=",
-			SaucerHead:    ">",
-			SaucerPadding: " ",
-			BarStart:      "[",
-			BarEnd:        "]",
-		}),
-	)
-
 	// Compute hash while downloading
 	hasher := sha256.New()
 	reader := io.TeeReader(resp.Body, hasher)
 
-	// Write to temp file with progress
-	_, err = io.Copy(io.MultiWriter(tmpFile, bar), reader)
+	// Write to temp file with optional progress
+	var dst io.Writer = tmpFile
+	if onProgress != nil {
+		if pw := onProgress(resp.ContentLength); pw != nil {
+			dst = io.MultiWriter(tmpFile, pw)
+		}
+	}
+	_, err = io.Copy(dst, reader)
 	if err != nil {
 		return fmt.Errorf("failed to write file: %w", err)
 	}

--- a/updex/install.go
+++ b/updex/install.go
@@ -74,7 +74,7 @@ func (c *Client) installTransfer(ctx context.Context, transfer *config.Transfer,
 	// Download
 	downloadURL := transfer.Source.Path + "/" + sourceFile
 	c.debug("downloading %s → %s", downloadURL, targetPath)
-	err = download.Download(ctx, downloadURL, targetPath, expectedHash, transfer.Target.Mode)
+	err = download.Download(ctx, downloadURL, targetPath, expectedHash, transfer.Target.Mode, c.config.OnDownloadProgress)
 	if err != nil {
 		return "", nil, false, fmt.Errorf("download failed: %w", err)
 	}

--- a/updex/updex.go
+++ b/updex/updex.go
@@ -18,6 +18,7 @@ package updex
 
 import (
 	"github.com/frostyard/std/reporter"
+	"github.com/frostyard/updex/download"
 	"github.com/frostyard/updex/sysext"
 )
 
@@ -52,6 +53,13 @@ type ClientConfig struct {
 	// If nil, uses the default runner that executes real commands.
 	// Set this in tests to inject a mock.
 	SysextRunner sysext.SysextRunner
+
+	// OnDownloadProgress is an optional callback for download progress tracking.
+	// If non-nil, it is passed to [download.Download] and called with the
+	// response content length (-1 if unknown). The returned io.Writer receives
+	// downloaded bytes. Return nil from the callback to disable progress for
+	// a given download.
+	OnDownloadProgress download.ProgressFunc
 }
 
 // NewClient creates a new updex API client with the given configuration.


### PR DESCRIPTION
In `download/download.go:58-75`, a terminal progress bar (`schollz/progressbar`) is unconditionally created for every download. Since the `download` package is part of the public SDK API (per OVERVIEW.md and issue #13), any Go program importing it will get unwanted terminal output. The progress bar should be optional — either accept an `io.Writer` (or nil to disable), or accept a progress callback function. The SDK client already has a `reporter.Reporter` abstraction (`updex/updex.go:28`); the download function should integrate with that instead of hardcoding terminal UI. This also removes the `schollz/progressbar` dependency from the library path.

---
*Automated improvement by yeti improvement-identifier*