### PR TITLE
refactor: Remove unused package-level sysext wrapper functions

### DIFF
--- a/sysext/manager.go
+++ b/sysext/manager.go
@@ -375,18 +375,3 @@ func RemoveAllVersions(t *config.Transfer) ([]string, error) {
 
 	return removed, nil
 }
-
-// Refresh calls systemd-sysext refresh to reload extensions
-func Refresh() error {
-	return runner.Refresh()
-}
-
-// Merge calls systemd-sysext merge to merge extensions
-func Merge() error {
-	return runner.Merge()
-}
-
-// Unmerge calls systemd-sysext unmerge to unmerge extensions
-func Unmerge() error {
-	return runner.Unmerge()
-}

--- a/sysext/runner.go
+++ b/sysext/runner.go
@@ -28,16 +28,6 @@ func (r *DefaultRunner) Unmerge() error {
 	return runSysextCommand("unmerge")
 }
 
-// runner is the package-level runner used by Refresh, Merge, Unmerge functions
-var runner SysextRunner = &DefaultRunner{}
-
-// SetRunner sets the runner for testing (returns cleanup function)
-func SetRunner(r SysextRunner) func() {
-	old := runner
-	runner = r
-	return func() { runner = old }
-}
-
 // runSysextCommand executes a systemd-sysext subcommand
 func runSysextCommand(subcommand string) error {
 	cmd := exec.Command("systemd-sysext", subcommand)

--- a/updex/features_test.go
+++ b/updex/features_test.go
@@ -765,8 +765,6 @@ func TestUpdateFeatures_MinVersion_FiltersVersions(t *testing.T) {
 	targetDir := t.TempDir()
 
 	mockRunner := &sysext.MockRunner{}
-	cleanup := sysext.SetRunner(mockRunner)
-	defer cleanup()
 
 	// Server has v0.9.0, v1.0.0, and v2.0.0 available
 	ext1Content := []byte("ext v0.9.0")
@@ -792,7 +790,7 @@ func TestUpdateFeatures_MinVersion_FiltersVersions(t *testing.T) {
 	createFeatureTransferFileWithMinVersion(t, configDir, "testext", "testfeature", server.URL, "1.0.0")
 	updateTransferTargetPath(t, configDir, targetDir)
 
-	client := NewClient(ClientConfig{Definitions: configDir})
+	client := NewClient(ClientConfig{Definitions: configDir, SysextRunner: mockRunner})
 	results, err := client.UpdateFeatures(t.Context(), UpdateFeaturesOptions{
 		NoRefresh: true,
 	})
@@ -831,8 +829,6 @@ func TestEnableFeature_Now_MinVersion_FiltersVersions(t *testing.T) {
 	targetDir := t.TempDir()
 
 	mockRunner := &sysext.MockRunner{}
-	cleanup := sysext.SetRunner(mockRunner)
-	defer cleanup()
 
 	ext1Content := []byte("ext v0.5.0")
 	ext2Content := []byte("ext v1.5.0")
@@ -854,7 +850,7 @@ func TestEnableFeature_Now_MinVersion_FiltersVersions(t *testing.T) {
 	createFeatureTransferFileWithMinVersion(t, configDir, "testext", "testfeature", server.URL, "1.0.0")
 	updateTransferTargetPath(t, configDir, targetDir)
 
-	client := NewClient(ClientConfig{Definitions: configDir})
+	client := NewClient(ClientConfig{Definitions: configDir, SysextRunner: mockRunner})
 	result, err := client.EnableFeature(t.Context(), "testfeature", EnableFeatureOptions{
 		Now:       true,
 		DryRun:    true, // dry-run to avoid /etc writes
@@ -884,8 +880,6 @@ func TestEnableFeature_Now_AlreadyInstalled(t *testing.T) {
 	targetDir := t.TempDir()
 
 	mockRunner := &sysext.MockRunner{}
-	cleanup := sysext.SetRunner(mockRunner)
-	defer cleanup()
 
 	extContent := []byte("fake extension content for already installed test")
 	extHash := hashContent(extContent)
@@ -912,7 +906,7 @@ func TestEnableFeature_Now_AlreadyInstalled(t *testing.T) {
 		t.Fatalf("failed to create symlink: %v", err)
 	}
 
-	client := NewClient(ClientConfig{Definitions: configDir})
+	client := NewClient(ClientConfig{Definitions: configDir, SysextRunner: mockRunner})
 	result, err := client.EnableFeature(t.Context(), "testfeature", EnableFeatureOptions{
 		Now:       true,
 		NoRefresh: true,
@@ -944,8 +938,6 @@ func TestUpdateFeatures_AlreadyInstalled_NotReportedAsDownloaded(t *testing.T) {
 	targetDir := t.TempDir()
 
 	mockRunner := &sysext.MockRunner{}
-	cleanup := sysext.SetRunner(mockRunner)
-	defer cleanup()
 
 	extContent := []byte("fake extension content")
 	extHash := hashContent(extContent)
@@ -972,7 +964,7 @@ func TestUpdateFeatures_AlreadyInstalled_NotReportedAsDownloaded(t *testing.T) {
 		t.Fatalf("failed to create symlink: %v", err)
 	}
 
-	client := NewClient(ClientConfig{Definitions: configDir})
+	client := NewClient(ClientConfig{Definitions: configDir, SysextRunner: mockRunner})
 	results, err := client.UpdateFeatures(t.Context(), UpdateFeaturesOptions{
 		NoRefresh: true,
 	})
@@ -1005,8 +997,6 @@ func TestUpdateFeatures_NoVacuum_Respected(t *testing.T) {
 	targetDir := t.TempDir()
 
 	mockRunner := &sysext.MockRunner{}
-	cleanup := sysext.SetRunner(mockRunner)
-	defer cleanup()
 
 	extContent := []byte("fake extension for vacuum test")
 	extHash := hashContent(extContent)
@@ -1025,7 +1015,7 @@ func TestUpdateFeatures_NoVacuum_Respected(t *testing.T) {
 	createFeatureTransferFile(t, configDir, "testext", "testfeature", server.URL)
 	updateTransferTargetPath(t, configDir, targetDir)
 
-	client := NewClient(ClientConfig{Definitions: configDir})
+	client := NewClient(ClientConfig{Definitions: configDir, SysextRunner: mockRunner})
 	results, err := client.UpdateFeatures(t.Context(), UpdateFeaturesOptions{
 		NoRefresh: true,
 		NoVacuum:  true,


### PR DESCRIPTION
In `sysext/manager.go:380-392`, the package-level functions `Refresh()`, `Merge()`, and `Unmerge()` delegate to a package-level `runner` variable (`sysext/runner.go:32`). These exist alongside the `SysextRunner` interface used by the SDK client. Grepping for callers shows no production code calls these — the SDK uses `c.runner.Refresh()` etc. directly, and `SetRunner()` (`sysext/runner.go:35`) is only called from `updex/features_test.go`. The package-level runner pattern (`var runner` + `SetRunner`) is a testing-only artifact that can be removed now that `ClientConfig.SysextRunner` provides proper dependency injection. Removing these eliminates a confusing dual-injection mechanism.

---
*Automated improvement by yeti improvement-identifier*