### PR TITLE
docs: update documentation for updex

### DIFF
--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -58,7 +58,6 @@ CLI (cmd/daemon.go) → systemd (direct, bypasses SDK)
 
 - Mock interfaces for system commands: `sysext.SysextRunner`, `systemd.SystemctlRunner`
 - `ClientConfig.SysextRunner` field for injecting mocks into the SDK client — `NewClient` stores the runner directly on the `Client` struct (does not mutate global state)
-- Package-level `SetRunner()` returning cleanup function exists on the `sysext` package for non-SDK test code
 - `internal/testutil.NewTestServer()` creates `httptest.Server` with configurable manifests and file content
 - `t.TempDir()` for filesystem operations, `t.Context()` for context
 

--- a/yeti/sdk-api.md
+++ b/yeti/sdk-api.md
@@ -8,17 +8,18 @@ The `updex` package (`github.com/frostyard/updex/updex`) is the primary public A
 type Client struct { /* unexported fields */ }
 
 type ClientConfig struct {
-    Definitions  string              // Custom config file path (overrides search paths)
-    Verify       bool                // Enable GPG signature verification
-    Verbose      bool                // Enable debug output
-    Progress     reporter.Reporter   // Progress reporter (optional)
-    SysextRunner sysext.SysextRunner // Mock runner for tests (optional)
+    Definitions        string                // Custom config file path (overrides search paths)
+    Verify             bool                  // Enable GPG signature verification
+    Verbose            bool                  // Enable debug output
+    Progress           reporter.Reporter     // Progress reporter (optional)
+    SysextRunner       sysext.SysextRunner   // Mock runner for tests (optional)
+    OnDownloadProgress download.ProgressFunc // Download progress callback (optional)
 }
 
 func NewClient(cfg ClientConfig) *Client
 ```
 
-`NewClient` stores the provided `SysextRunner` directly on the `Client` struct. If `SysextRunner` is nil, it defaults to `&sysext.DefaultRunner{}`. If `Progress` is nil, it defaults to `reporter.NoopReporter{}`. The client does not mutate global package state.
+`NewClient` stores the provided `SysextRunner` directly on the `Client` struct. If `SysextRunner` is nil, it defaults to `&sysext.DefaultRunner{}`. If `Progress` is nil, it defaults to `reporter.NoopReporter{}`. `OnDownloadProgress` is passed through to `download.Download` calls — when non-nil, it is called with the HTTP response content length (-1 if unknown) and should return an `io.Writer` that receives downloaded bytes for progress tracking (return nil to skip progress for that download). The client does not mutate global package state.
 
 ## Methods
 
@@ -164,7 +165,8 @@ type CheckResult struct {
 
 ### `download`
 
-- `Download(ctx context.Context, url, targetPath, expectedHash string, mode uint32) error` — Download with hash verification (on compressed bytes) and auto-decompression. Uses atomic rename (falls back to copy on cross-device). HTTP timeout: 10 minutes. Default mode: `0644` if `mode == 0`
+- `Download(ctx context.Context, url, targetPath, expectedHash string, mode uint32, onProgress ProgressFunc) error` — Download with hash verification (on compressed bytes) and auto-decompression. Uses atomic rename (falls back to atomic copy on cross-device). HTTP timeout: 10 minutes. Default mode: `0644` if `mode == 0`. `onProgress` is called with the response content length; the returned `io.Writer` receives downloaded bytes. Pass nil to disable progress tracking
+- `ProgressFunc` — `func(contentLength int64) io.Writer` callback type for download progress
 - `DecompressReader(r io.Reader, compressionType string) (io.ReadCloser, error)` — Returns a decompressing reader for `"xz"`, `"gz"`, `"zstd"`, or passthrough for `""`
 
 ### `version`
@@ -183,8 +185,7 @@ type CheckResult struct {
 
 ### `sysext`
 
-- `Refresh() / Merge() / Unmerge()` — Package-level convenience functions delegating to a global runner
-- `SetRunner(r SysextRunner) func()` — Inject mock runner globally (returns cleanup). Used by non-SDK test code; SDK tests should use `ClientConfig.SysextRunner` instead
+- `SysextRunner` interface — `Refresh()`, `Merge()`, `Unmerge()` methods executed via `DefaultRunner` (real commands) or `MockRunner` (tests)
 - `GetInstalledVersions(t *config.Transfer) ([]string, string, error)` — List installed + current version
 - `GetActiveVersion(t *config.Transfer) (string, error)` — Get version currently active in systemd-sysext (checks current symlink and `/run/extensions`)
 - `UpdateSymlink(targetDir, symlinkName, targetFile string) error`


### PR DESCRIPTION
## Summary

Documentation updated to reflect recent refactoring changes: the addition of optional download progress reporting via callback, the removal of unused package-level sysext wrapper functions, and the atomic cross-device rename fix.

## Changes

- **Added** `OnDownloadProgress` field and `ProgressFunc` callback type to SDK API docs (`sdk-api.md`)
- **Updated** `download.Download` signature to include the new `onProgress` parameter
- **Updated** cross-device rename description from "fallback to copy" to "fallback to atomic copy"
- **Removed** references to package-level `SetRunner()` and global sysext convenience functions (`Refresh`/`Merge`/`Unmerge`), replaced with `SysextRunner` interface description
- **Removed** mention of `SetRunner()` from testing patterns in `OVERVIEW.md`