### PR TITLE
fix: compare Debian-style versions correctly and protect active sysext version

### DIFF
--- a/sysext/manager.go
+++ b/sysext/manager.go
@@ -208,9 +208,29 @@ func VacuumWithDetails(t *config.Transfer) (removed []string, kept []string, err
 		instancesMax = 2
 	}
 
+	// Resolve the active version (the one the CurrentSymlink points at). It must
+	// never be removed regardless of how it sorts, otherwise vacuum would leave
+	// a dangling symlink — which is exactly what happens when the version
+	// comparator can't rank a freshly downloaded image above older ones.
+	activeVersion := ""
+	if t.Target.CurrentSymlink != "" {
+		symlinkPath := filepath.Join(targetDir, t.Target.CurrentSymlink)
+		if target, err := os.Readlink(symlinkPath); err == nil {
+			if v, _, ok := version.ExtractVersionParsed(filepath.Base(target), patterns); ok {
+				activeVersion = v
+			}
+		}
+	}
+
 	for i, vf := range installed {
 		v := vf.version
 		fullPath := filepath.Join(targetDir, vf.filename)
+
+		// Always keep the active (symlinked) version.
+		if activeVersion != "" && v == activeVersion {
+			kept = append(kept, v)
+			continue
+		}
 
 		// Always keep protected versions
 		if t.Transfer.ProtectVersion != "" && v == t.Transfer.ProtectVersion {

--- a/sysext/manager_test.go
+++ b/sysext/manager_test.go
@@ -264,6 +264,70 @@ func TestVacuumWithDetails(t *testing.T) {
 	}
 }
 
+func TestVacuumWithDetailsKeepsActiveSymlinkedVersion(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Three versions present; the current symlink points at the OLDEST one.
+	// This reproduces the dangling-symlink failure: vacuum must never delete
+	// the file the CurrentSymlink resolves to, even when it sorts oldest.
+	files := []string{
+		"myext_1.0.0.raw",
+		"myext_2.0.0.raw",
+		"myext_3.0.0.raw",
+	}
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(tmpDir, f), []byte("test"), 0644); err != nil {
+			t.Fatalf("failed to create test file: %v", err)
+		}
+	}
+
+	// Active version = 1.0.0 (the oldest).
+	if err := os.Symlink("myext_1.0.0.raw", filepath.Join(tmpDir, "myext.raw")); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	transfer := &config.Transfer{
+		Transfer: config.TransferSection{
+			InstancesMax: 1, // Keep only 1 by count...
+		},
+		Target: config.TargetSection{
+			Path:           tmpDir,
+			MatchPattern:   "myext_@v.raw",
+			CurrentSymlink: "myext.raw",
+		},
+	}
+
+	removed, kept, err := VacuumWithDetails(transfer)
+	if err != nil {
+		t.Fatalf("VacuumWithDetails() error = %v", err)
+	}
+
+	keptMap := make(map[string]bool)
+	for _, v := range kept {
+		keptMap[v] = true
+	}
+	// ...but the active version must be kept on top of the count.
+	if !keptMap["1.0.0"] {
+		t.Error("active (symlinked) version 1.0.0 must be kept")
+	}
+	if !keptMap["3.0.0"] {
+		t.Error("newest version 3.0.0 should be kept")
+	}
+
+	// The active file must still exist on disk (no dangling symlink).
+	if _, err := os.Stat(filepath.Join(tmpDir, "myext_1.0.0.raw")); err != nil {
+		t.Errorf("active file myext_1.0.0.raw must still exist: %v", err)
+	}
+
+	removedMap := make(map[string]bool)
+	for _, v := range removed {
+		removedMap[v] = true
+	}
+	if !removedMap["2.0.0"] {
+		t.Error("non-active middle version 2.0.0 should be removed")
+	}
+}
+
 func TestVacuumWithDetailsProtectedVersion(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/version/pattern.go
+++ b/version/pattern.go
@@ -3,6 +3,7 @@ package version
 import (
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	goversion "github.com/hashicorp/go-version"
@@ -132,6 +133,15 @@ func ExtractVersionParsed(filename string, patterns []*Pattern) (version string,
 // Compare compares two version strings
 // Returns -1 if v1 < v2, 0 if v1 == v2, 1 if v1 > v2
 func Compare(v1, v2 string) int {
+	// Debian-style versions (epoch with ':' or tilde-revisions like
+	// "5+29.4.2-2~debian.13~trixie") cannot be compared by semver: hashicorp
+	// go-version treats everything after '+' as build metadata and ignores it,
+	// so every such version collapses to the same precedence. Route these to a
+	// dpkg-compatible comparator instead.
+	if isDebianVersion(v1) || isDebianVersion(v2) {
+		return compareDebian(v1, v2)
+	}
+
 	ver1, err1 := goversion.NewVersion(normalizeVersion(v1))
 	ver2, err2 := goversion.NewVersion(normalizeVersion(v2))
 
@@ -166,6 +176,134 @@ func normalizeVersion(v string) string {
 	// Replace underscores with dots (common in some versioning schemes)
 	// But be careful not to break things like "1.0_rc1"
 	return v
+}
+
+// isDebianVersion reports whether v looks like a Debian/dpkg version string,
+// i.e. it carries an epoch (':') or a tilde ('~'). Tilde is never valid in
+// SemVer, and an explicit epoch is the canonical Debian marker, so either is a
+// reliable signal that semver comparison would be wrong.
+func isDebianVersion(v string) bool {
+	return strings.ContainsAny(v, "~:")
+}
+
+// compareDebian compares two version strings using Debian/dpkg precedence
+// rules: epoch first (numeric), then upstream version, then debian revision,
+// each segment compared with the dpkg algorithm where '~' sorts before
+// everything (including end-of-string).
+func compareDebian(a, b string) int {
+	ea, ua, ra := splitDebian(a)
+	eb, ub, rb := splitDebian(b)
+
+	if ea != eb {
+		if ea < eb {
+			return -1
+		}
+		return 1
+	}
+	if c := verrevcmp(ua, ub); c != 0 {
+		return c
+	}
+	return verrevcmp(ra, rb)
+}
+
+// splitDebian splits a version into epoch, upstream version, and debian
+// revision. Format: [epoch:]upstream[-revision]. A missing epoch is 0; a
+// missing revision is the empty string.
+func splitDebian(v string) (epoch int, upstream, revision string) {
+	if i := strings.IndexByte(v, ':'); i >= 0 {
+		if e, err := strconv.Atoi(v[:i]); err == nil {
+			epoch = e
+			v = v[i+1:]
+		}
+	}
+	if i := strings.LastIndexByte(v, '-'); i >= 0 {
+		upstream = v[:i]
+		revision = v[i+1:]
+	} else {
+		upstream = v
+	}
+	return epoch, upstream, revision
+}
+
+// verrevcmp is a port of dpkg's version segment comparison. It compares two
+// strings in alternating runs of non-digit and digit characters. Non-digit
+// runs are compared by dpkgOrder (so '~' sorts first); digit runs are compared
+// numerically with leading zeros ignored.
+func verrevcmp(a, b string) int {
+	i, j := 0, 0
+	for i < len(a) || j < len(b) {
+		// Compare the non-digit prefix.
+		for (i < len(a) && !isASCIIDigit(a[i])) || (j < len(b) && !isASCIIDigit(b[j])) {
+			var ac, bc int
+			if i < len(a) {
+				ac = dpkgOrder(a[i])
+			}
+			if j < len(b) {
+				bc = dpkgOrder(b[j])
+			}
+			if ac != bc {
+				return sign(ac - bc)
+			}
+			i++
+			j++
+		}
+		// Skip leading zeros in the digit run.
+		for i < len(a) && a[i] == '0' {
+			i++
+		}
+		for j < len(b) && b[j] == '0' {
+			j++
+		}
+		// Compare the digit run: a longer run of digits is the larger number.
+		firstDiff := 0
+		for i < len(a) && j < len(b) && isASCIIDigit(a[i]) && isASCIIDigit(b[j]) {
+			if firstDiff == 0 {
+				firstDiff = int(a[i]) - int(b[j])
+			}
+			i++
+			j++
+		}
+		if i < len(a) && isASCIIDigit(a[i]) {
+			return 1
+		}
+		if j < len(b) && isASCIIDigit(b[j]) {
+			return -1
+		}
+		if firstDiff != 0 {
+			return sign(firstDiff)
+		}
+	}
+	return 0
+}
+
+// dpkgOrder maps a character to its dpkg sort weight. Digits are handled
+// separately (weight 0); letters keep their ASCII value; '~' sorts before
+// everything else including end-of-string (weight -1); other characters sort
+// after letters.
+func dpkgOrder(c byte) int {
+	switch {
+	case isASCIIDigit(c):
+		return 0
+	case (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'):
+		return int(c)
+	case c == '~':
+		return -1
+	default:
+		return int(c) + 256
+	}
+}
+
+func isASCIIDigit(c byte) bool { return c >= '0' && c <= '9' }
+
+func sign(n int) int {
+	switch {
+	case n < 0:
+		return -1
+	case n > 0:
+		return 1
+	default:
+		return 0
+	}
 }
 
 // Errors

--- a/version/pattern_test.go
+++ b/version/pattern_test.go
@@ -313,6 +313,42 @@ func TestCompare(t *testing.T) {
 			v2:   "def",
 			want: -1,
 		},
+		{
+			name: "debian newer upstream patch",
+			v1:   "5+29.4.2-2~debian.13~trixie",
+			v2:   "5+29.3.1-1~debian.13~trixie",
+			want: 1,
+		},
+		{
+			name: "debian older upstream patch",
+			v1:   "5+29.3.0-1~debian.13~trixie",
+			v2:   "5+29.3.1-1~debian.13~trixie",
+			want: -1,
+		},
+		{
+			name: "debian equal full version",
+			v1:   "5+29.4.2-2~debian.13~trixie",
+			v2:   "5+29.4.2-2~debian.13~trixie",
+			want: 0,
+		},
+		{
+			name: "debian tilde sorts before release",
+			v1:   "1.0.0~rc1",
+			v2:   "1.0.0",
+			want: -1,
+		},
+		{
+			name: "debian epoch dominates",
+			v1:   "2:1.0",
+			v2:   "1:5.0",
+			want: 1,
+		},
+		{
+			name: "debian revision breaks tie",
+			v1:   "1.0-2~debian",
+			v2:   "1.0-1~debian",
+			want: 1,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

The `docker.raw` sysext symlink ended up dangling: it pointed at `docker_5+29.4.2-2~debian.13~trixie...` but no such file existed on disk, so systemd-sysext could not merge the docker extension.

### Root cause

`version.Compare` passed Debian-style versions like `5+29.4.2-2~debian.13~trixie` to `hashicorp/go-version`, which treats everything after `+` as **SemVer build metadata and excludes it from precedence comparison**. Every docker version therefore collapsed to core `5.0.0` and compared **equal**.

`VacuumWithDetails` runs *after* the new symlink is created and keeps the newest `InstancesMax` versions. With all versions comparing equal, the sort was a no-op and "keep newest N" deleted the **freshly downloaded** image (which sorted last lexically), leaving the dangling symlink.

## Fix

- **`version/pattern.go`** — versions containing `~` or `:` are routed to a dpkg-compatible comparator (epoch → upstream → revision, with `~` sorting before everything, including end-of-string). The SemVer path is unchanged, so existing prerelease/`v`-prefix/date behavior is preserved.
- **`sysext/manager.go`** — `VacuumWithDetails` now never removes the active (symlinked) version regardless of sort order. Defense-in-depth that prevents a dangling symlink even if the comparator is wrong.

## Tests

- `TestCompare`: Debian upstream/epoch/revision/tilde ordering, including the exact `5+29.4.2-2~...` vs `5+29.3.1-1~...` case.
- `TestVacuumWithDetailsKeepsActiveSymlinkedVersion`: reproduces the failure (symlink points at the oldest version) and asserts the active file is never deleted.

## Validation

Built the patched binary and ran it against the live repo: docker `29.5.2` downloaded, symlink repaired, and the new image **survived vacuum** (it pruned the oldest `29.3.0` instead). `docker --version` → `29.5.2`, merged into `/usr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)