### PR TITLE
fix: resolve #118 — [yeti-test] Add a --quiet flag to suppress non-error output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,8 @@ Entry point: `cmd/updex-cli/main.go` → `cmd/updex/root.go`
 
 - Error messages: lowercase, no trailing punctuation, wrap with `fmt.Errorf("context: %w", err)`
 - SDK functions accept a `context.Context` and an options struct, return result structs + error
-- CLI output: `common.OutputJSON()` for `--json` flag, text tables otherwise
+- CLI output: `clix.OutputJSON()` for `--json` flag, text tables otherwise
+- Quiet mode: the global `-q, --quiet` flag (see `cmd/updex/output.go`) suppresses all non-error stdout — SDK reporter output, the download progress bar, result tables, and confirmation lines. Non-error CLI output must go through `outPrintln`/`outPrintf` (which honor `isQuiet()`); errors are returned from `RunE` so fang prints them to stderr. `--json` output is preserved under `--quiet`. `isQuiet()` also treats the clix `--silent`/`-s` flag as equivalent.
 - Tests use `t.TempDir()` for filesystem operations and mock runners for systemd commands
 - Configuration uses INI format with systemd-style priority paths: `/etc/sysupdate.d/`, `/run/sysupdate.d/`, `/usr/local/lib/sysupdate.d/`, `/usr/lib/sysupdate.d/`
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ sudo updex daemon disable
 | `--json` | Output in JSON format (jq-compatible) |
 | `--dry-run` | Preview changes without modifying filesystem |
 | `--verbose` | Enable verbose output |
+| `-q, --quiet` | Suppress non-error output (progress, info logs, and result tables); errors still go to stderr |
 
 ## Configuration
 

--- a/cmd/updex/client.go
+++ b/cmd/updex/client.go
@@ -16,8 +16,8 @@ func newClient() *updex.Client {
 		Definitions:        definitions,
 		Verify:             verify,
 		Verbose:            clix.Verbose,
-		Progress:           clix.NewReporter(),
-		OnDownloadProgress: newProgressBar,
+		Progress:           selectReporter(),
+		OnDownloadProgress: selectDownloadProgress(),
 	})
 }
 

--- a/cmd/updex/daemon.go
+++ b/cmd/updex/daemon.go
@@ -10,6 +10,11 @@ import (
 
 const unitName = "updex-update"
 
+// updateExecStart is the command the auto-update timer runs. It uses --quiet so
+// the timer/journal only records real errors, and --no-refresh to stage updates
+// without activating them until reboot.
+const updateExecStart = "/usr/bin/updex features update --no-refresh --quiet"
+
 type daemonStatus struct {
 	Installed bool   `json:"installed"`
 	Enabled   bool   `json:"enabled"`
@@ -94,7 +99,7 @@ func runDaemonEnable(cmd *cobra.Command, args []string) error {
 	service := &systemd.ServiceConfig{
 		Name:        unitName,
 		Description: "Automatic sysext update service",
-		ExecStart:   "/usr/bin/updex features update --no-refresh",
+		ExecStart:   updateExecStart,
 		Type:        "oneshot",
 	}
 
@@ -118,9 +123,9 @@ func runDaemonEnable(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Println("Auto-update daemon enabled.")
-	fmt.Println("Updates will run daily and download new versions.")
-	fmt.Println("Reboot required to activate downloaded extensions.")
+	outPrintln("Auto-update daemon enabled.")
+	outPrintln("Updates will run daily and download new versions.")
+	outPrintln("Reboot required to activate downloaded extensions.")
 	return nil
 }
 
@@ -169,8 +174,8 @@ func runDaemonDisable(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Println("Auto-update daemon disabled.")
-	fmt.Println("Automatic updates will no longer run.")
+	outPrintln("Auto-update daemon disabled.")
+	outPrintln("Automatic updates will no longer run.")
 	return nil
 }
 
@@ -218,14 +223,14 @@ func runDaemonStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	if !status.Installed {
-		fmt.Println("Auto-update daemon: not installed")
-		fmt.Println("Run 'updex daemon enable' to enable automatic updates.")
+		outPrintln("Auto-update daemon: not installed")
+		outPrintln("Run 'updex daemon enable' to enable automatic updates.")
 		return nil
 	}
 
-	fmt.Println("Auto-update daemon: installed")
-	fmt.Printf("  Enabled: %v\n", status.Enabled)
-	fmt.Printf("  Active: %v\n", status.Active)
-	fmt.Printf("  Schedule: %s\n", status.Schedule)
+	outPrintln("Auto-update daemon: installed")
+	outPrintf("  Enabled: %v\n", status.Enabled)
+	outPrintf("  Active: %v\n", status.Active)
+	outPrintf("  Schedule: %s\n", status.Schedule)
 	return nil
 }

--- a/cmd/updex/daemon_test.go
+++ b/cmd/updex/daemon_test.go
@@ -1,0 +1,15 @@
+package updex
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUpdateExecStartIsQuiet(t *testing.T) {
+	if !strings.Contains(updateExecStart, "--quiet") {
+		t.Errorf("updateExecStart = %q, want it to include --quiet", updateExecStart)
+	}
+	if !strings.Contains(updateExecStart, "--no-refresh") {
+		t.Errorf("updateExecStart = %q, want it to include --no-refresh", updateExecStart)
+	}
+}

--- a/cmd/updex/features_run.go
+++ b/cmd/updex/features_run.go
@@ -25,7 +25,11 @@ func runFeaturesList(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(features) == 0 {
-		fmt.Println("No features configured.")
+		outPrintln("No features configured.")
+		return nil
+	}
+
+	if isQuiet() {
 		return nil
 	}
 
@@ -74,22 +78,18 @@ func runFeaturesEnable(cmd *cobra.Command, args []string) error {
 
 	if clix.JSONOutput {
 		_, _ = clix.OutputJSON(result)
-	} else if result != nil {
-		if result.Error != "" {
-			fmt.Printf("Error: %s\n", result.Error)
-		} else if result.Success {
-			if result.DryRun {
-				fmt.Printf("[DRY RUN] %s\n", result.NextActionMessage)
-			} else {
-				fmt.Printf("Feature '%s' enabled.\n", result.Feature)
-				if len(result.DownloadedFiles) > 0 {
-					fmt.Printf("Downloaded %d extension(s):\n", len(result.DownloadedFiles))
-					for _, f := range result.DownloadedFiles {
-						fmt.Printf("  - %s\n", f)
-					}
-				} else if !featureEnableNow {
-					fmt.Printf("Run 'updex features update' to download extensions.\n")
+	} else if result != nil && result.Error == "" && result.Success {
+		if result.DryRun {
+			outPrintf("[DRY RUN] %s\n", result.NextActionMessage)
+		} else {
+			outPrintf("Feature '%s' enabled.\n", result.Feature)
+			if len(result.DownloadedFiles) > 0 {
+				outPrintf("Downloaded %d extension(s):\n", len(result.DownloadedFiles))
+				for _, f := range result.DownloadedFiles {
+					outPrintf("  - %s\n", f)
 				}
+			} else if !featureEnableNow {
+				outPrintf("Run 'updex features update' to download extensions.\n")
 			}
 		}
 	}
@@ -115,28 +115,24 @@ func runFeaturesDisable(cmd *cobra.Command, args []string) error {
 
 	if clix.JSONOutput {
 		_, _ = clix.OutputJSON(result)
-	} else if result != nil {
-		if result.Error != "" {
-			fmt.Printf("Error: %s\n", result.Error)
-		} else if result.Success {
-			if result.DryRun {
-				fmt.Printf("[DRY RUN] %s\n", result.NextActionMessage)
-			} else {
-				fmt.Printf("Feature '%s' disabled.\n", result.Feature)
-				if result.Unmerged {
-					fmt.Printf("Extensions unmerged.\n")
+	} else if result != nil && result.Error == "" && result.Success {
+		if result.DryRun {
+			outPrintf("[DRY RUN] %s\n", result.NextActionMessage)
+		} else {
+			outPrintf("Feature '%s' disabled.\n", result.Feature)
+			if result.Unmerged {
+				outPrintf("Extensions unmerged.\n")
+			}
+			if len(result.RemovedFiles) > 0 {
+				outPrintf("Removed %d file(s):\n", len(result.RemovedFiles))
+				for _, f := range result.RemovedFiles {
+					outPrintf("  - %s\n", f)
 				}
-				if len(result.RemovedFiles) > 0 {
-					fmt.Printf("Removed %d file(s):\n", len(result.RemovedFiles))
-					for _, f := range result.RemovedFiles {
-						fmt.Printf("  - %s\n", f)
-					}
-				}
-				if featureDisableForce {
-					fmt.Printf("Warning: Reboot required for changes to take effect.\n")
-				} else if !featureDisableNow {
-					fmt.Printf("Run 'updex features update' to apply changes.\n")
-				}
+			}
+			if featureDisableForce {
+				outPrintf("Warning: Reboot required for changes to take effect.\n")
+			} else if !featureDisableNow {
+				outPrintf("Run 'updex features update' to apply changes.\n")
 			}
 		}
 	}
@@ -164,7 +160,11 @@ func runFeaturesUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(results) == 0 {
-		fmt.Println("No enabled features with transfers found.")
+		outPrintln("No enabled features with transfers found.")
+		return err
+	}
+
+	if isQuiet() {
 		return err
 	}
 
@@ -199,7 +199,11 @@ func runFeaturesCheck(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(results) == 0 {
-		fmt.Println("No enabled features with transfers found.")
+		outPrintln("No enabled features with transfers found.")
+		return err
+	}
+
+	if isQuiet() {
 		return err
 	}
 

--- a/cmd/updex/output.go
+++ b/cmd/updex/output.go
@@ -1,0 +1,49 @@
+package updex
+
+import (
+	"fmt"
+
+	"github.com/frostyard/clix"
+	"github.com/frostyard/std/reporter"
+	"github.com/frostyard/updex/download"
+)
+
+// isQuiet reports whether non-error output should be suppressed. It treats the
+// clix --silent/-s flag as equivalent to --quiet so both suppress output.
+func isQuiet() bool {
+	return quiet || clix.Silent
+}
+
+// outPrintln writes a line to stdout unless quiet mode is enabled.
+func outPrintln(a ...any) {
+	if isQuiet() {
+		return
+	}
+	fmt.Println(a...)
+}
+
+// outPrintf writes formatted output to stdout unless quiet mode is enabled.
+func outPrintf(format string, a ...any) {
+	if isQuiet() {
+		return
+	}
+	fmt.Printf(format, a...)
+}
+
+// selectReporter returns the SDK progress reporter to use. In quiet mode all
+// progress/info/warning output is discarded via a NoopReporter.
+func selectReporter() reporter.Reporter {
+	if isQuiet() {
+		return reporter.NoopReporter{}
+	}
+	return clix.NewReporter()
+}
+
+// selectDownloadProgress returns the download progress callback to use. In quiet
+// mode no progress bar is drawn (nil disables progress reporting in the SDK).
+func selectDownloadProgress() download.ProgressFunc {
+	if isQuiet() {
+		return nil
+	}
+	return newProgressBar
+}

--- a/cmd/updex/output_test.go
+++ b/cmd/updex/output_test.go
@@ -1,0 +1,156 @@
+package updex
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/frostyard/clix"
+	"github.com/frostyard/std/reporter"
+	"github.com/spf13/cobra"
+)
+
+// resetQuietState resets the global quiet-related flags after a test.
+func resetQuietState(t *testing.T) {
+	t.Helper()
+	prevQuiet := quiet
+	prevSilent := clix.Silent
+	prevDefs := definitions
+	t.Cleanup(func() {
+		quiet = prevQuiet
+		clix.Silent = prevSilent
+		definitions = prevDefs
+	})
+}
+
+// captureStdout runs fn while capturing everything written to os.Stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	_ = w.Close()
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	return buf.String()
+}
+
+func TestIsQuiet(t *testing.T) {
+	resetQuietState(t)
+
+	tests := []struct {
+		name   string
+		quiet  bool
+		silent bool
+		want   bool
+	}{
+		{"neither", false, false, false},
+		{"quiet only", true, false, true},
+		{"silent only", false, true, true},
+		{"both", true, true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			quiet = tt.quiet
+			clix.Silent = tt.silent
+			if got := isQuiet(); got != tt.want {
+				t.Errorf("isQuiet() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSelectReporter(t *testing.T) {
+	resetQuietState(t)
+
+	quiet = true
+	clix.Silent = false
+	if _, ok := selectReporter().(reporter.NoopReporter); !ok {
+		t.Errorf("selectReporter() with quiet = %T, want NoopReporter", selectReporter())
+	}
+
+	quiet = false
+	clix.Silent = true
+	if _, ok := selectReporter().(reporter.NoopReporter); !ok {
+		t.Errorf("selectReporter() with silent = %T, want NoopReporter", selectReporter())
+	}
+
+	quiet = false
+	clix.Silent = false
+	clix.JSONOutput = false
+	r := selectReporter()
+	if r.IsJSON() {
+		t.Errorf("selectReporter() default should not be JSON reporter")
+	}
+	if _, ok := r.(reporter.NoopReporter); ok {
+		t.Errorf("selectReporter() default should not be NoopReporter")
+	}
+}
+
+func TestSelectDownloadProgress(t *testing.T) {
+	resetQuietState(t)
+
+	quiet = true
+	if selectDownloadProgress() != nil {
+		t.Error("selectDownloadProgress() with quiet should be nil")
+	}
+
+	quiet = false
+	clix.Silent = false
+	if selectDownloadProgress() == nil {
+		t.Error("selectDownloadProgress() without quiet should be non-nil")
+	}
+}
+
+func TestFeaturesListQuietSuppressesOutput(t *testing.T) {
+	resetQuietState(t)
+	definitions = t.TempDir() // empty dir -> no features configured
+
+	// Non-quiet: prints the informational line.
+	quiet = false
+	clix.Silent = false
+	out := captureStdout(t, func() {
+		if err := runFeaturesList(&cobra.Command{}, nil); err != nil {
+			t.Fatalf("runFeaturesList: %v", err)
+		}
+	})
+	if !strings.Contains(out, "No features configured.") {
+		t.Errorf("expected informational output, got %q", out)
+	}
+
+	// Quiet: suppresses all stdout.
+	quiet = true
+	out = captureStdout(t, func() {
+		if err := runFeaturesList(&cobra.Command{}, nil); err != nil {
+			t.Fatalf("runFeaturesList: %v", err)
+		}
+	})
+	if out != "" {
+		t.Errorf("expected no output in quiet mode, got %q", out)
+	}
+}
+
+func TestFeaturesCheckQuietSuppressesOutput(t *testing.T) {
+	resetQuietState(t)
+	definitions = t.TempDir()
+
+	quiet = true
+	clix.Silent = false
+	out := captureStdout(t, func() {
+		_ = runFeaturesCheck(&cobra.Command{}, nil)
+	})
+	if out != "" {
+		t.Errorf("expected no output in quiet mode, got %q", out)
+	}
+}

--- a/cmd/updex/root.go
+++ b/cmd/updex/root.go
@@ -11,12 +11,14 @@ var (
 	definitions string
 	verify      bool
 	noRefresh   bool
+	quiet       bool
 )
 
 func registerAppFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(&definitions, "definitions", "C", "", "Path to directory containing .transfer and .feature files")
 	cmd.PersistentFlags().BoolVar(&verify, "verify", false, "Verify GPG signatures on SHA256SUMS")
 	cmd.PersistentFlags().BoolVar(&noRefresh, "no-refresh", false, "Skip running systemd-sysext refresh after install/update")
+	cmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "Suppress non-error output (progress, info logs, and result tables)")
 }
 
 func requireRoot() error {

--- a/cmd/updex/root_test.go
+++ b/cmd/updex/root_test.go
@@ -21,3 +21,18 @@ func TestRequireRoot(t *testing.T) {
 		}
 	}
 }
+
+func TestQuietFlagRegistered(t *testing.T) {
+	cmd := NewRootCmd()
+
+	f := cmd.PersistentFlags().Lookup("quiet")
+	if f == nil {
+		t.Fatal("--quiet flag not registered")
+	}
+	if f.Shorthand != "q" {
+		t.Errorf("--quiet shorthand = %q, want %q", f.Shorthand, "q")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("--quiet default = %q, want %q", f.DefValue, "false")
+	}
+}

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -15,6 +15,7 @@ cmd/updex/features.go           features list|enable|disable|update|check
 cmd/updex/features_run.go       Run functions for feature subcommands
 cmd/updex/daemon.go             daemon enable|disable|status (systemd timers)
 cmd/updex/client.go             CLI → SDK client factory
+cmd/updex/output.go             Quiet-aware output helpers + reporter/progress selection
 
 updex/                          Public SDK (Client + methods)
   updex.go                      Client struct, NewClient()
@@ -164,7 +165,17 @@ Global flags:
   --json                                Output as JSON (from clix)
   --dry-run                             Preview without modifying filesystem (from clix)
   --verbose                             Enable debug output (from clix)
+  -q, --quiet                           Suppress non-error output (errors still go to stderr)
+  -s, --silent                          Alias for --quiet (from clix); also disables the download progress bar
 ```
+
+> `--quiet` suppresses all non-error stdout: SDK progress/info/warning reporting,
+> the download progress bar, result tables, and success/confirmation lines.
+> Errors are unaffected and are printed to stderr by the fang/cobra layer.
+> `--json` output is still emitted (it is an explicit data request). The clix
+> `--silent`/`-s` flag is treated as equivalent to `--quiet`. The auto-update
+> timer installed by `daemon enable` runs `updex features update --no-refresh
+> --quiet` so the journal only records real errors.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

This PR adds a global `-q, --quiet` flag to updex that suppresses all non-error output—SDK progress/info reporting, the download progress bar, result tables, and success/confirmation lines—so the tool can be used cleanly in scripts. Errors are unaffected and continue to go to stderr via the fang/cobra layer, and `--json` output is preserved as an explicit data request. The flag composes with existing flags like `--dry-run`, and the clix `--silent`/`-s` flag is treated as equivalent.

## Changes

- Added a global `-q, --quiet` persistent flag in `cmd/updex/root.go`.
- Introduced `cmd/updex/output.go` with quiet-aware helpers: `isQuiet()`, `outPrintln`/`outPrintf`, plus `selectReporter()` (returns a `NoopReporter` when quiet) and `selectDownloadProgress()` (disables the progress bar when quiet).
- Routed all non-error CLI output in the `features` and `daemon` commands through the quiet-aware helpers, and wired the client factory to the new reporter/progress selectors.
- Updated the auto-update timer installed by `daemon enable` to run `updex features update --no-refresh --quiet` so the journal only records real errors.
- Added tests covering flag registration, `isQuiet()` behavior, reporter/progress selection, quiet output suppression, and the daemon ExecStart command.
- Updated documentation (`README.md`, `CLAUDE.md`, `yeti/OVERVIEW.md`) to describe the new flag and its semantics.

Closes #118