### PR TITLE
docs: update documentation for updex

### DIFF
--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -4,7 +4,7 @@
 
 updex is a Go SDK and CLI for managing [systemd-sysext](https://www.freedesktop.org/software/systemd/man/latest/systemd-sysext.html) images. It replicates `systemd-sysupdate` functionality for `url-file` transfers, providing feature-based management of system extensions with version tracking, SHA256 verification, optional GPG signing, and automatic cleanup.
 
-The project follows an **SDK-first design**: all logic lives in public Go packages, and the CLI is a thin wrapper that parses flags and formats output.
+The project follows an **SDK-first design** for feature management: the core workflows live in public Go packages, and the CLI is mostly a thin wrapper that parses flags and formats output. The `daemon` command is the main exception: it imports the `systemd` package directly to install/remove timer units.
 
 ## Architecture
 
@@ -13,7 +13,7 @@ cmd/updex-cli/main.go          Entry point (frostyard/clix bootstrap)
 cmd/updex/root.go               Cobra root command, global flags
 cmd/updex/features.go           features list|enable|disable|update|check
 cmd/updex/features_run.go       Run functions for feature subcommands
-cmd/updex/daemon.go             daemon enable|disable|status (systemd timers)
+cmd/updex/daemon.go             daemon enable|disable|status (direct systemd timers)
 cmd/updex/client.go             CLI → SDK client factory
 
 updex/                          Public SDK (Client + methods)
@@ -29,11 +29,11 @@ updex/                          Public SDK (Client + methods)
   options.go                    Option structs for all operations
   results.go                    Result structs for all operations
 
-config/                         .transfer and .feature INI file parsing
-                                (shared collectConfigFiles helper for directory scanning)
+config/                         .transfer and .feature INI file parsing,
+                                search paths, drop-ins, and specifiers
 download/                       HTTP download with SHA256 + decompression
 manifest/                       SHA256SUMS manifest fetch/parse + GPG verify
-version/                        Pattern matching (@v placeholder) + semver compare
+version/                        Pattern matching (@v placeholder) + version compare
 sysext/                         systemd-sysext operations (refresh/merge/vacuum)
 systemd/                        systemd unit generation + systemctl management
 internal/testutil/              HTTP test server helpers (module-internal)
@@ -42,8 +42,8 @@ internal/testutil/              HTTP test server helpers (module-internal)
 ### Package dependency flow
 
 ```
-CLI (cmd/) → SDK (updex/) → config, download, manifest, version, sysext
-                         → sysext → config, version
+CLI (cmd/features*) → SDK (updex/) → config, manifest, download, version, sysext
+                                  → sysext → config, version
 CLI (cmd/daemon.go) → systemd (direct, bypasses SDK)
 ```
 
@@ -56,6 +56,8 @@ CLI (cmd/daemon.go) → systemd (direct, bypasses SDK)
 - All public SDK methods take `context.Context` as first parameter for cancellation
 - Operations use dedicated option structs (e.g., `EnableFeatureOptions`, `UpdateFeaturesOptions`) to allow future expansion without breaking changes
 - Return dedicated result structs with status fields + error
+- `ClientConfig.HTTPClient` is reused for manifest fetches and downloads; if nil, `NewClient` creates one with a 10-minute timeout
+- `ClientConfig.Progress` receives informational/warning/debug messages; `ClientConfig.OnDownloadProgress` is a separate download-byte callback
 - Error messages: lowercase, no trailing punctuation, wrapped with `fmt.Errorf("context: %w", err)`
 
 ### Testing patterns
@@ -68,11 +70,19 @@ CLI (cmd/daemon.go) → systemd (direct, bypasses SDK)
 ### CLI output
 
 - Text tables by default, JSON with `--json` flag — both `--json` and `--dry-run` are provided by the `github.com/frostyard/clix` package, not defined in this repo
+- `cmd/updex/client.go` always wires `clix.NewReporter()` and `newProgressBar`; there is no repo-defined `--quiet` flag in the current code
 - Operations requiring filesystem changes call `requireRoot()` to enforce root access
 
 ### Public API (Issue #13)
 
 All core packages (`config`, `version`, `download`, `manifest`, `sysext`, `systemd`) are exported as public API at `github.com/frostyard/updex/<package>`. Only `internal/testutil` remains internal. This was an intentional decision: the types in these packages (e.g., `Transfer`, `Feature`, `Pattern`, `Manifest`) were designed with exported fields and are suitable for external consumption.
+
+### Version and pattern conventions
+
+- Every match pattern must contain `@v`; other `@` placeholders match UUIDs, flags, file metadata, and hashes but are not substituted when building target filenames
+- `.transfer` `MatchPattern` fields may contain multiple space-separated alternatives; the first is preserved in `MatchPattern`, while all alternatives are available via `Patterns()`
+- `%` specifiers in transfer values are expanded at parse time with a cached context per `LoadTransfers` call
+- `version.Compare` uses `hashicorp/go-version` for normal semver-like versions, but routes Debian/dpkg-looking versions containing `:` or `~` through a dpkg-compatible comparator so epochs and tildes sort correctly
 
 ## Configuration
 
@@ -126,19 +136,26 @@ Transfer file values support systemd-style `%` specifiers. See [Configuration Re
 3. For each transfer:
    - Fetch `SHA256SUMS` manifest from source URL (+ GPG verify if configured); manifests are cached by source URL across transfers so that multiple transfers sharing the same source make only one HTTP request
    - Parse source patterns and extract available versions using pattern matching (`@v` placeholder); parsed patterns are returned to callers so `installTransfer` reuses them without re-parsing
-   - Select newest version via semver comparison
+   - Select newest version via `version.Sort` (semver where possible, Debian/dpkg ordering for versions with `:` or `~`, string fallback otherwise)
    - Skip if already installed (check target directory)
    - Download file, verify SHA256 hash of compressed bytes during transfer
    - Decompress if needed (xz, gz, zstd — detected from filename)
    - Atomically rename to final path, update `CurrentSymlink`
    - Create symlink in `/var/lib/extensions/` pointing to extension
-   - Vacuum old versions per `InstancesMax`
+   - Vacuum old versions per `InstancesMax`; the active symlink target and `ProtectVersion` are always kept
 4. Call `systemd-sysext refresh` to reload all extensions (unless `--no-refresh`). Callers batch this — `installTransfer` is called with `NoRefresh: true` per-component, and a single refresh runs at the end
 
 ### Enable/disable feature
 
 - **Enable**: Creates drop-in at `/etc/sysupdate.d/<name>.feature.d/00-updex.conf` setting `Enabled=true`. With `--now`, also downloads extensions immediately.
 - **Disable**: Creates drop-in setting `Enabled=false`. With `--now`, calls `Unmerge()`, removes symlinks from `/var/lib/extensions/`, and deletes all versioned files. `--force` required if extensions are currently active/merged (changes take effect after reboot).
+
+### Auto-update daemon
+
+- `updex daemon enable` installs `/etc/systemd/system/updex-update.timer` and `.service`, then enables and starts the timer
+- The timer runs `daily`, is `Persistent=true`, and uses `RandomizedDelaySec=3600`
+- The service command is `/usr/bin/updex features update --no-refresh`, so automatic downloads are staged and not refreshed/activated until a later refresh or reboot
+- Unit installation refuses to overwrite existing timer/service files; callers must disable first
 
 ## CLI Commands
 

--- a/yeti/config-reference.md
+++ b/yeti/config-reference.md
@@ -91,7 +91,7 @@ Mode=0644
 | Key | Type | Description |
 |-----|------|-------------|
 | `Type` | string | Source type (currently `url-file` supported) |
-| `Path` | string | Base URL for downloads (must end with `/`) |
+| `Path` | string | Base URL for downloads; trailing slashes are trimmed during parsing |
 | `MatchPattern` | string | Filename pattern(s) with `@v` placeholder. Space-separated values define compression variants tried in order |
 
 ### `[Target]` section
@@ -107,7 +107,7 @@ Mode=0644
 
 ### Multiple `MatchPattern` values
 
-`MatchPattern` accepts space-separated patterns on a single line. The first is the primary pattern; additional entries are compression variants. During download, patterns are tried in order to find a matching file in the manifest.
+`MatchPattern` accepts space-separated patterns on a single line. The first is the primary pattern kept in `MatchPattern` for backward-compatible callers; the full ordered list is stored in `MatchPatterns`. During download, all valid source patterns are used to find matching files in the manifest.
 
 ```ini
 MatchPattern=component_@v.raw.xz component_@v.raw.gz component_@v.raw
@@ -115,7 +115,7 @@ MatchPattern=component_@v.raw.xz component_@v.raw.gz component_@v.raw
 
 Specifiers (`%a`, `%v`, `%w`, etc.) are expanded on each pattern after splitting.
 
-In Go code, the `Transfer` struct stores both `MatchPattern` (first pattern, for backward compatibility) and `MatchPatterns` (all patterns). The `Patterns()` method on `SourceSection`/`TargetSection` returns the canonical list.
+In Go code, the `Transfer` struct stores both `MatchPattern` (first pattern, for backward compatibility) and `MatchPatterns` (all patterns). The `Patterns()` method on `SourceSection`/`TargetSection` returns the canonical list. Invalid patterns are skipped by `version.ParsePatterns`; callers fail only when no valid pattern remains.
 
 ## Pattern Placeholders
 
@@ -160,4 +160,8 @@ String values in transfer files support systemd-style `%` specifiers, expanded a
 
 ## Version Comparison
 
-Versions extracted via `@v` are compared using `hashicorp/go-version` (semantic versioning). If a version string cannot be parsed as semver, string comparison is used as fallback. Versions are sorted descending (newest first) when selecting which version to install.
+Versions extracted via `@v` are sorted descending (newest first) when selecting which version to install. `version.Compare` uses a dpkg-compatible comparator for Debian-style versions containing `:` or `~` so epochs and tilde pre-release ordering work correctly. Other versions are compared with `hashicorp/go-version` after stripping a leading `v`/`V`; if parsing fails, plain string comparison is used as fallback.
+
+## Retention and Active Versions
+
+`InstancesMax` controls how many installed versions are normally retained. During `sysext.VacuumWithDetails`, the active version pointed to by `CurrentSymlink` is always kept even if it would otherwise sort outside the retention window, and `ProtectVersion` is always kept as well. If `InstancesMax <= 0`, vacuum falls back to the default of `2`.

--- a/yeti/sdk-api.md
+++ b/yeti/sdk-api.md
@@ -20,7 +20,7 @@ type ClientConfig struct {
 func NewClient(cfg ClientConfig) *Client
 ```
 
-`NewClient` stores the provided `SysextRunner` directly on the `Client` struct. If `SysextRunner` is nil, it defaults to `&sysext.DefaultRunner{}`. If `Progress` is nil, it defaults to `reporter.NoopReporter{}`. `OnDownloadProgress` is passed through to `download.Download` calls — when non-nil, it is called with the HTTP response content length (-1 if unknown) and should return an `io.Writer` that receives downloaded bytes for progress tracking (return nil to skip progress for that download). If `HTTPClient` is nil, a default `http.Client` with a 10-minute timeout is created and reused for all manifest fetches and file downloads, enabling HTTP keep-alive connection reuse. The client does not mutate global package state.
+`NewClient` stores the provided `SysextRunner` directly on the `Client` struct. If `SysextRunner` is nil, it defaults to `&sysext.DefaultRunner{}`. If `Progress` is nil, it defaults to `reporter.NoopReporter{}`. `OnDownloadProgress` is passed through to `download.Download` calls — when non-nil, it is called with the HTTP response content length (-1 if unknown) and should return an `io.Writer` that receives downloaded bytes for progress tracking (return nil to skip progress for that download). If `HTTPClient` is nil, a default `http.Client` with a 10-minute timeout is created and reused for all manifest fetches and file downloads, enabling HTTP keep-alive connection reuse. The client stores the original config and does not mutate global package state.
 
 ## Methods
 
@@ -175,7 +175,7 @@ type CheckResult struct {
 - `ParsePattern(pattern string) (*Pattern, error)` — Parse `@v`-style patterns. Returns `ErrEmptyPattern` or `ErrMissingVersionPlaceholder` on invalid input
 - `ParsePatterns(patternStrs []string) ([]*Pattern, error)` — Parse multiple patterns; returns all successfully parsed patterns and the first error encountered (callers proceed if at least one pattern parsed)
 - `ExtractVersionParsed(filename string, patterns []*Pattern) (version, matchedPattern string, ok bool)` — Try pre-parsed patterns against a filename (preferred for loops)
-- `Compare(v1, v2 string) int` — Semver comparison (-1, 0, 1); normalizes by stripping `v`/`V` prefix; falls back to string comparison
+- `Compare(v1, v2 string) int` — Version comparison (-1, 0, 1); uses dpkg-compatible ordering for Debian-style versions containing `:` or `~`, otherwise normalizes `v`/`V` prefixes and uses semantic comparison with string fallback
 - `Sort(versions []string)` — Sort descending (newest first)
 
 **`Pattern` methods:**
@@ -191,7 +191,7 @@ type CheckResult struct {
 - `GetActiveVersion(t *config.Transfer) (string, error)` — Get version currently active in systemd-sysext (checks current symlink and `/run/extensions`)
 - `UpdateSymlink(targetDir, symlinkName, targetFile string) error`
 - `LinkToSysext(t *config.Transfer) / UnlinkFromSysext(t *config.Transfer)` — Manage `/var/lib/extensions` symlinks
-- `Vacuum(t *config.Transfer) / VacuumWithDetails(t *config.Transfer)` — Clean old versions
+- `Vacuum(t *config.Transfer) / VacuumWithDetails(t *config.Transfer)` — Clean old versions while keeping the active symlink target and `ProtectVersion`
 - `RemoveAllVersions(t *config.Transfer) ([]string, error)` — Remove all versions and current symlink for a component
 - `GetExtensionName(filename string) string` — Extract extension name from filename (strips version and compression suffixes)
 - `SysextDir` — Constant: `/var/lib/extensions`


### PR DESCRIPTION
## Summary

This documentation update aligns the Yeti AI-facing docs with current updex behavior. It clarifies the SDK-first architecture boundaries, version comparison behavior, transfer pattern handling, HTTP/progress client configuration, retention rules, and the auto-update daemon workflow.

## Changes

- Updated `yeti/OVERVIEW.md` to clarify that feature commands use the SDK while `daemon` directly manages systemd timer units.
- Expanded architecture notes for config parsing, dependency flow, CLI output behavior, client HTTP/progress handling, and daemon installation semantics.
- Added version and pattern conventions, including `@v` requirements, multi-pattern transfer handling, specifier expansion, and Debian/dpkg-aware sorting.
- Updated workflow docs to describe manifest caching, parsed pattern reuse, version sorting, sysext refresh batching, and vacuum protections.
- Revised `yeti/config-reference.md` for trailing slash normalization, `MatchPatterns` behavior, invalid pattern handling, version comparison, and retention of active/protected versions.
- Updated `yeti/sdk-api.md` to document stored client config, dpkg-aware `version.Compare`, and `VacuumWithDetails` preservation rules.