### PR TITLE
fix: resolve #114 — features update ignores --dry-run (performs real download, install, and sysext merge)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Key packages:
 - `download/` — HTTP downloads with SHA256 verification and decompression (xz, gz, zstd)
 - `manifest/` — Fetches/parses SHA256SUMS manifests with optional GPG verification
 - `version/` — Pattern matching (`@v` placeholder) and semantic version comparison
-- `sysext/` — systemd-sysext integration with mockable `Runner` interface
+- `sysext/` — systemd-sysext integration with mockable `Runner` interface and read-only vacuum planning helpers
 - `systemd/` — Generates/installs systemd timer+service units, mockable `Runner` interface
 
 Entry point: `cmd/updex-cli/main.go` → `cmd/updex/root.go`

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ type DisableFeatureOptions struct {
 }
 
 type UpdateFeaturesOptions struct {
+    DryRun    bool // Preview changes without modifying filesystem or sysext state
     NoRefresh bool // Skip systemd-sysext refresh after update
     NoVacuum  bool // Skip removing old versions after update
 }
@@ -183,6 +184,9 @@ sudo updex features update
 
 # Update without removing old versions
 sudo updex features update --no-vacuum
+
+# Preview downloads, installs, refreshes, and vacuum removals
+sudo updex --dry-run features update
 
 # Check for available updates (read-only)
 updex features check

--- a/cmd/updex/features.go
+++ b/cmd/updex/features.go
@@ -161,12 +161,18 @@ OPTIONS:
   --no-refresh  Skip running systemd-sysext refresh after update
   --no-vacuum   Skip removing old versions after update
 
+Use --dry-run (global flag) to preview downloads, installs, refreshes, and
+vacuum removals without modifying filesystem or sysext state.
+
 Requires root privileges.`,
 		Example: `  # Update all enabled features
   sudo updex features update
 
   # Update without refreshing sysext
   sudo updex features update --no-refresh
+
+  # Preview what would be updated
+  sudo updex --dry-run features update
 
   # Update in JSON format
   sudo updex features update --json`,

--- a/cmd/updex/features_run.go
+++ b/cmd/updex/features_run.go
@@ -152,6 +152,7 @@ func runFeaturesUpdate(cmd *cobra.Command, args []string) error {
 	client := newClient()
 
 	opts := updex.UpdateFeaturesOptions{
+		DryRun:    clix.DryRun,
 		NoRefresh: noRefresh,
 		NoVacuum:  featureUpdateNoVac,
 	}
@@ -168,6 +169,10 @@ func runFeaturesUpdate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if clix.DryRun {
+		fmt.Println("[DRY RUN] Previewing feature updates.")
+	}
+
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "FEATURE\tCOMPONENT\tVERSION\tSTATUS")
 	for _, fr := range results {
@@ -175,6 +180,8 @@ func runFeaturesUpdate(cmd *cobra.Command, args []string) error {
 			status := "error"
 			if r.Error != "" {
 				status = r.Error
+			} else if r.DryRun && r.Downloaded {
+				status = "would download"
 			} else if r.Downloaded {
 				status = "downloaded"
 			} else if r.Installed {

--- a/cmd/updex/features_run_test.go
+++ b/cmd/updex/features_run_test.go
@@ -1,0 +1,137 @@
+package updex
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/frostyard/clix"
+	"github.com/frostyard/updex/internal/testutil"
+	"github.com/spf13/cobra"
+)
+
+func writeFeatureFile(t *testing.T, configDir, name string, enabled bool) {
+	t.Helper()
+	enabledStr := "false"
+	if enabled {
+		enabledStr = "true"
+	}
+	content := "[Feature]\nDescription=Test feature\nEnabled=" + enabledStr + "\n"
+	if err := os.WriteFile(filepath.Join(configDir, name+".feature"), []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write feature file: %v", err)
+	}
+}
+
+func writeFeatureTransferFile(t *testing.T, configDir, targetDir, component, feature, baseURL string) {
+	t.Helper()
+	content := `[Transfer]
+Features=` + feature + `
+
+[Source]
+Type=url-file
+Path=` + baseURL + `
+MatchPattern=` + component + `_@v.raw
+
+[Target]
+Path=` + targetDir + `
+MatchPattern=` + component + `_@v.raw
+CurrentSymlink=` + component + `.raw
+`
+	if err := os.WriteFile(filepath.Join(configDir, component+".transfer"), []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write transfer file: %v", err)
+	}
+}
+
+func sha256Hex(content []byte) string {
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
+}
+
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	original := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdout pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() {
+		os.Stdout = original
+	}()
+
+	runErr := fn()
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close stdout pipe: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("failed to read stdout: %v", err)
+	}
+
+	return buf.String(), runErr
+}
+
+func TestRunFeaturesUpdate_ThreadsDryRun(t *testing.T) {
+	configDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	extContent := []byte("fake extension content")
+	server := testutil.NewTestServer(t, testutil.TestServerFiles{
+		Files: map[string]string{
+			"testext_1.0.0.raw": sha256Hex(extContent),
+		},
+		Content: map[string][]byte{
+			"testext_1.0.0.raw": extContent,
+		},
+	})
+	defer server.Close()
+
+	writeFeatureFile(t, configDir, "testfeature", true)
+	writeFeatureTransferFile(t, configDir, targetDir, "testext", "testfeature", server.URL)
+
+	oldDefinitions, oldNoRefresh, oldFeatureUpdateNoVac := definitions, noRefresh, featureUpdateNoVac
+	oldDryRun, oldJSONOutput := clix.DryRun, clix.JSONOutput
+	oldGetEUID := getEUID
+	t.Cleanup(func() {
+		definitions = oldDefinitions
+		noRefresh = oldNoRefresh
+		featureUpdateNoVac = oldFeatureUpdateNoVac
+		clix.DryRun = oldDryRun
+		clix.JSONOutput = oldJSONOutput
+		getEUID = oldGetEUID
+	})
+
+	definitions = configDir
+	noRefresh = false
+	featureUpdateNoVac = false
+	clix.DryRun = true
+	clix.JSONOutput = false
+	getEUID = func() int { return 0 }
+
+	output, err := captureStdout(t, func() error {
+		cmd := &cobra.Command{}
+		cmd.SetContext(t.Context())
+		return runFeaturesUpdate(cmd, nil)
+	})
+	if err != nil {
+		t.Fatalf("runFeaturesUpdate failed: %v", err)
+	}
+	if !strings.Contains(output, "[DRY RUN]") {
+		t.Fatalf("expected dry-run header in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "would download") {
+		t.Fatalf("expected would-download status in output, got:\n%s", output)
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, "testext_1.0.0.raw")); !os.IsNotExist(err) {
+		t.Error("expected CLI dry-run to avoid downloading the extension file")
+	}
+	if _, err := os.Lstat(filepath.Join(targetDir, "testext.raw")); !os.IsNotExist(err) {
+		t.Error("expected CLI dry-run to avoid creating the current symlink")
+	}
+}

--- a/cmd/updex/root.go
+++ b/cmd/updex/root.go
@@ -11,6 +11,7 @@ var (
 	definitions string
 	verify      bool
 	noRefresh   bool
+	getEUID     = os.Geteuid
 )
 
 func registerAppFlags(cmd *cobra.Command) {
@@ -20,7 +21,7 @@ func registerAppFlags(cmd *cobra.Command) {
 }
 
 func requireRoot() error {
-	if os.Geteuid() != 0 {
+	if getEUID() != 0 {
 		return fmt.Errorf("this operation requires root privileges")
 	}
 	return nil

--- a/sysext/manager.go
+++ b/sysext/manager.go
@@ -150,6 +150,17 @@ func UpdateSymlink(targetDir, symlinkName, targetFile string) error {
 	return nil
 }
 
+type versionFile struct {
+	version  string
+	filename string
+}
+
+// PlanVacuumAfterInstall returns the versions that vacuum would remove/keep
+// after installing activeVersion, without deleting files.
+func PlanVacuumAfterInstall(t *config.Transfer, activeVersion string) (removed []string, kept []string, err error) {
+	return planVacuum(t, activeVersion, nil, false)
+}
+
 // Vacuum removes old versions according to InstancesMax
 func Vacuum(t *config.Transfer) error {
 	_, _, err := VacuumWithDetails(t)
@@ -158,6 +169,10 @@ func Vacuum(t *config.Transfer) error {
 
 // VacuumWithDetails removes old versions and returns what was removed/kept
 func VacuumWithDetails(t *config.Transfer) (removed []string, kept []string, err error) {
+	return planVacuum(t, "", nil, true)
+}
+
+func planVacuum(t *config.Transfer, activeVersionOverride string, extraVersions []string, remove bool) (removed []string, kept []string, err error) {
 	patterns, err := parseTargetPatterns(t)
 	if err != nil {
 		return nil, nil, err
@@ -173,12 +188,8 @@ func VacuumWithDetails(t *config.Transfer) (removed []string, kept []string, err
 		return nil, nil, fmt.Errorf("failed to read directory: %w", err)
 	}
 
-	// Collect installed versions with their filenames
-	type versionFile struct {
-		version  string
-		filename string
-	}
 	var installed []versionFile
+	seenVersions := make(map[string]bool)
 
 	for _, entry := range entries {
 		name := entry.Name()
@@ -190,7 +201,18 @@ func VacuumWithDetails(t *config.Transfer) (removed []string, kept []string, err
 
 		if v, _, ok := version.ExtractVersionParsed(name, patterns); ok {
 			installed = append(installed, versionFile{v, name})
+			seenVersions[v] = true
 		}
+	}
+
+	for _, v := range extraVersions {
+		if v != "" && !seenVersions[v] {
+			installed = append(installed, versionFile{version: v})
+			seenVersions[v] = true
+		}
+	}
+	if activeVersionOverride != "" && !seenVersions[activeVersionOverride] {
+		installed = append(installed, versionFile{version: activeVersionOverride})
 	}
 
 	if len(installed) == 0 {
@@ -212,8 +234,8 @@ func VacuumWithDetails(t *config.Transfer) (removed []string, kept []string, err
 	// never be removed regardless of how it sorts, otherwise vacuum would leave
 	// a dangling symlink — which is exactly what happens when the version
 	// comparator can't rank a freshly downloaded image above older ones.
-	activeVersion := ""
-	if t.Target.CurrentSymlink != "" {
+	activeVersion := activeVersionOverride
+	if activeVersion == "" && t.Target.CurrentSymlink != "" {
 		symlinkPath := filepath.Join(targetDir, t.Target.CurrentSymlink)
 		if target, err := os.Readlink(symlinkPath); err == nil {
 			if v, _, ok := version.ExtractVersionParsed(filepath.Base(target), patterns); ok {
@@ -245,8 +267,10 @@ func VacuumWithDetails(t *config.Transfer) (removed []string, kept []string, err
 		}
 
 		// Remove old version
-		if err := os.Remove(fullPath); err != nil {
-			return removed, kept, fmt.Errorf("failed to remove %s: %w", vf.filename, err)
+		if remove {
+			if err := os.Remove(fullPath); err != nil {
+				return removed, kept, fmt.Errorf("failed to remove %s: %w", vf.filename, err)
+			}
 		}
 		removed = append(removed, v)
 	}

--- a/updex/features.go
+++ b/updex/features.go
@@ -392,9 +392,11 @@ func (c *Client) UpdateFeatures(ctx context.Context, opts UpdateFeaturesOptions)
 
 			result := UpdateResult{
 				Component: transfer.Component,
+				DryRun:    opts.DryRun,
 			}
 
 			v, m, downloaded, err := c.installTransfer(ctx, transfer, installTransferOptions{
+				DryRun:         opts.DryRun,
 				NoVacuum:       opts.NoVacuum,
 				NoRefresh:      true, // refresh is batched at the end
 				CachedManifest: manifestCache[transfer.Source.Path],
@@ -413,9 +415,24 @@ func (c *Client) UpdateFeatures(ctx context.Context, opts UpdateFeaturesOptions)
 			result.Version = v
 			if downloaded {
 				result.Downloaded = true
-				result.Installed = true
-				result.NextActionMessage = "Reboot required to activate changes"
-				c.msg("Installed version %s", v)
+				if opts.DryRun {
+					result.NextActionMessage = "Would download and install version " + v
+					if !opts.NoVacuum {
+						removed, _, err := sysext.PlanVacuumAfterInstall(transfer, v)
+						if err != nil {
+							c.warn("failed to plan vacuum for %s: %v", transfer.Component, err)
+						}
+						result.RemovedVersions = removed
+						if len(removed) > 0 {
+							result.NextActionMessage += fmt.Sprintf("; would remove old versions: %v", removed)
+						}
+					}
+					c.msg("Would install version %s", v)
+				} else {
+					result.Installed = true
+					result.NextActionMessage = "Reboot required to activate changes"
+					c.msg("Installed version %s", v)
+				}
 			} else {
 				result.Installed = true
 				c.msg("Version %s already installed and current", v)
@@ -427,7 +444,9 @@ func (c *Client) UpdateFeatures(ctx context.Context, opts UpdateFeaturesOptions)
 		allResults = append(allResults, featureResult)
 	}
 
-	if !opts.NoRefresh {
+	if opts.DryRun {
+		c.msg("Dry run: skipping sysext refresh")
+	} else if !opts.NoRefresh {
 		if err := c.runner.Refresh(); err != nil {
 			c.warn("sysext refresh failed: %v", err)
 		}

--- a/updex/features_test.go
+++ b/updex/features_test.go
@@ -662,6 +662,86 @@ func TestUpdateFeatures_DownloadsForEnabledFeatures(t *testing.T) {
 	}
 }
 
+// TestUpdateFeatures_DryRun_NoMutations verifies dry-run reports planned work
+// without downloading, updating symlinks, linking sysexts, refreshing, or vacuuming.
+func TestUpdateFeatures_DryRun_NoMutations(t *testing.T) {
+	configDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	mockRunner := &sysext.MockRunner{}
+
+	extContent := []byte("fake extension content for dry-run update test")
+	extHash := hashContent(extContent)
+
+	server := testutil.NewTestServer(t, testutil.TestServerFiles{
+		Files: map[string]string{
+			"testext_2.0.0.raw": extHash,
+		},
+		Content: map[string][]byte{
+			"testext_2.0.0.raw": extContent,
+		},
+	})
+	defer server.Close()
+
+	createFeatureFile(t, configDir, "testfeature", true)
+	createFeatureTransferFile(t, configDir, "testext", "testfeature", server.URL)
+	updateTransferTargetPath(t, configDir, targetDir)
+
+	for _, filename := range []string{"testext_0.9.0.raw", "testext_1.0.0.raw"} {
+		if err := os.WriteFile(filepath.Join(targetDir, filename), []byte("old extension"), 0644); err != nil {
+			t.Fatalf("failed to write %s: %v", filename, err)
+		}
+	}
+
+	client := NewClient(ClientConfig{Definitions: configDir, SysextRunner: mockRunner})
+	results, err := client.UpdateFeatures(t.Context(), UpdateFeaturesOptions{
+		DryRun: true,
+	})
+
+	if err != nil {
+		t.Fatalf("UpdateFeatures failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 feature result, got %d", len(results))
+	}
+	if len(results[0].Results) != 1 {
+		t.Fatalf("expected 1 component result, got %d", len(results[0].Results))
+	}
+
+	r := results[0].Results[0]
+	if !r.DryRun {
+		t.Error("expected DryRun=true")
+	}
+	if !r.Downloaded {
+		t.Error("expected Downloaded=true to mean would download")
+	}
+	if r.Installed {
+		t.Error("expected Installed=false in dry-run would-install result")
+	}
+	if r.Version != "2.0.0" {
+		t.Errorf("expected Version=2.0.0, got %q", r.Version)
+	}
+	if len(r.RemovedVersions) != 1 || r.RemovedVersions[0] != "0.9.0" {
+		t.Errorf("expected RemovedVersions=[0.9.0], got %v", r.RemovedVersions)
+	}
+
+	if _, err := os.Stat(filepath.Join(targetDir, "testext_2.0.0.raw")); !os.IsNotExist(err) {
+		t.Error("expected extension file to NOT exist in dry-run mode")
+	}
+	if _, err := os.Lstat(filepath.Join(targetDir, "testext.raw")); !os.IsNotExist(err) {
+		t.Error("expected current symlink to NOT exist in dry-run mode")
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, "testext_0.9.0.raw")); err != nil {
+		t.Errorf("expected old extension to remain after dry-run vacuum preview: %v", err)
+	}
+	if mockRunner.LinkToSysextCalled {
+		t.Error("expected LinkToSysext to NOT be called in dry-run mode")
+	}
+	if mockRunner.RefreshCalled {
+		t.Error("expected Refresh to NOT be called in dry-run mode")
+	}
+}
+
 // TestUpdateFeatures_SkipsDisabledFeatures verifies UpdateFeatures skips disabled features
 func TestUpdateFeatures_SkipsDisabledFeatures(t *testing.T) {
 	configDir := t.TempDir()

--- a/updex/install.go
+++ b/updex/install.go
@@ -67,6 +67,11 @@ func (c *Client) installTransfer(ctx context.Context, transfer *config.Transfer,
 
 	// Download
 	downloadURL := transfer.Source.Path + "/" + sourceFile
+	if opts.DryRun {
+		c.debug("would download %s → %s", downloadURL, targetPath)
+		return versionToInstall, m, true, nil
+	}
+
 	c.debug("downloading %s → %s", downloadURL, targetPath)
 	err = download.Download(ctx, c.httpClient, downloadURL, targetPath, expectedHash, transfer.Target.Mode, c.config.OnDownloadProgress)
 	if err != nil {

--- a/updex/options.go
+++ b/updex/options.go
@@ -4,6 +4,9 @@ import "github.com/frostyard/updex/manifest"
 
 // UpdateFeaturesOptions configures the UpdateFeatures operation.
 type UpdateFeaturesOptions struct {
+	// DryRun previews changes without modifying filesystem.
+	DryRun bool
+
 	// NoRefresh skips running systemd-sysext refresh after update.
 	NoRefresh bool
 
@@ -28,6 +31,9 @@ type EnableFeatureOptions struct {
 
 // installTransferOptions configures the installTransfer operation.
 type installTransferOptions struct {
+	// DryRun skips filesystem and sysext mutations.
+	DryRun bool
+
 	// NoVacuum skips removing old versions after install.
 	NoVacuum bool
 

--- a/updex/results.go
+++ b/updex/results.go
@@ -10,12 +10,14 @@ type CheckResult struct {
 
 // UpdateResult represents the result of an update operation for a single component.
 type UpdateResult struct {
-	Component         string `json:"component"`
-	Version           string `json:"version"`
-	Downloaded        bool   `json:"downloaded"`
-	Installed         bool   `json:"installed"`
-	Error             string `json:"error,omitempty"`
-	NextActionMessage string `json:"next_action_message,omitempty"`
+	Component         string   `json:"component"`
+	Version           string   `json:"version"`
+	Downloaded        bool     `json:"downloaded"`
+	Installed         bool     `json:"installed"`
+	DryRun            bool     `json:"dry_run,omitempty"`
+	Error             string   `json:"error,omitempty"`
+	NextActionMessage string   `json:"next_action_message,omitempty"`
+	RemovedVersions   []string `json:"removed_versions,omitzero"`
 }
 
 // UpdateFeaturesResult represents the result of updating all enabled features.

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -133,7 +133,7 @@ Transfer file values support systemd-style `%` specifiers. See [Configuration Re
    - Atomically rename to final path, update `CurrentSymlink`
    - Create symlink in `/var/lib/extensions/` pointing to extension
    - Vacuum old versions per `InstancesMax`
-4. Call `systemd-sysext refresh` to reload all extensions (unless `--no-refresh`). Callers batch this — `installTransfer` is called with `NoRefresh: true` per-component, and a single refresh runs at the end
+4. Call `systemd-sysext refresh` to reload all extensions (unless `--no-refresh`). Callers batch this — `installTransfer` is called with `NoRefresh: true` per-component, and a single refresh runs at the end. With `--dry-run`, the same manifest/version resolution runs, but `installTransfer` returns before download; `UpdateFeatures` reports would-download/would-install results and read-only vacuum removals, then skips the final refresh.
 
 ### Enable/disable feature
 
@@ -151,6 +151,7 @@ updex features disable <name>           Disable a feature
   --force                               Allow removal of merged extensions
 updex features update                   Download and install new versions
   --no-vacuum                           Skip removing old versions
+  --dry-run                             Preview update work without filesystem/sysext changes
 updex features check                    Check for available updates
 
 updex daemon enable                     Install daily auto-update timer

--- a/yeti/sdk-api.md
+++ b/yeti/sdk-api.md
@@ -62,11 +62,12 @@ Enable creates a drop-in file setting `Enabled=true`. With `Now: true`, it downl
 func (c *Client) UpdateFeatures(ctx context.Context, opts UpdateFeaturesOptions) ([]UpdateFeaturesResult, error)
 ```
 
-Downloads and installs the newest available version for each enabled feature's transfers. Delegates per-component work to the internal `installTransfer` pipeline (which handles download, symlink, sysext linking, and vacuum). Manifests are cached by source URL — transfers sharing the same source avoid redundant HTTP requests. Parsed source patterns are returned from version listing and reused by the install pipeline to avoid redundant pattern compilation. Refresh is batched — a single `systemd-sysext refresh` runs after all components are processed. Returns per-feature results with per-component status.
+Downloads and installs the newest available version for each enabled feature's transfers. Delegates per-component work to the internal `installTransfer` pipeline (which handles download, symlink, sysext linking, and vacuum). Manifests are cached by source URL — transfers sharing the same source avoid redundant HTTP requests. Parsed source patterns are returned from version listing and reused by the install pipeline to avoid redundant pattern compilation. Refresh is batched — a single `systemd-sysext refresh` runs after all components are processed. With `DryRun: true`, manifests are fetched and versions are selected, but download, symlink update, sysext linking, refresh, and vacuum deletion are skipped. Returns per-feature results with per-component status.
 
 **UpdateFeaturesOptions:**
 | Field | Type | Description |
 |-------|------|-------------|
+| `DryRun` | `bool` | Preview downloads, installs, refreshes, and vacuum removals without modifying filesystem or sysext state |
 | `NoRefresh` | `bool` | Skip `systemd-sysext refresh` after updates |
 | `NoVacuum` | `bool` | Skip removing old versions |
 
@@ -122,14 +123,18 @@ type UpdateFeaturesResult struct {
 }
 
 type UpdateResult struct {
-    Component         string `json:"component"`
-    Version           string `json:"version"`
-    Downloaded        bool   `json:"downloaded"`
-    Installed         bool   `json:"installed"`
-    Error             string `json:"error,omitempty"`
-    NextActionMessage string `json:"next_action_message,omitempty"`
+    Component         string   `json:"component"`
+    Version           string   `json:"version"`
+    Downloaded        bool     `json:"downloaded"`
+    Installed         bool     `json:"installed"`
+    DryRun            bool     `json:"dry_run,omitempty"`
+    Error             string   `json:"error,omitempty"`
+    NextActionMessage string   `json:"next_action_message,omitempty"`
+    RemovedVersions   []string `json:"removed_versions,omitzero"`
 }
 ```
+
+For dry-run update results, `Downloaded=true` means the component would be downloaded, `Installed=false` means no install was performed, and `RemovedVersions` lists versions vacuum would remove if `NoVacuum` is false.
 
 ### CheckFeaturesResult / CheckResult
 
@@ -191,6 +196,7 @@ type CheckResult struct {
 - `GetActiveVersion(t *config.Transfer) (string, error)` — Get version currently active in systemd-sysext (checks current symlink and `/run/extensions`)
 - `UpdateSymlink(targetDir, symlinkName, targetFile string) error`
 - `LinkToSysext(t *config.Transfer) / UnlinkFromSysext(t *config.Transfer)` — Manage `/var/lib/extensions` symlinks
+- `PlanVacuumAfterInstall(t *config.Transfer, activeVersion string) ([]string, []string, error)` — Preview vacuum removals/kept versions after installing a version without deleting files
 - `Vacuum(t *config.Transfer) / VacuumWithDetails(t *config.Transfer)` — Clean old versions
 - `RemoveAllVersions(t *config.Transfer) ([]string, error)` — Remove all versions and current symlink for a component
 - `GetExtensionName(filename string) string` — Extract extension name from filename (strips version and compression suffixes)


### PR DESCRIPTION
## Summary

`updex features update` accepted the global `--dry-run` flag but ignored it, performing real downloads, symlink updates, sysext linking, refresh, and vacuum deletions — contradicting the flag's contract and risking unintended system changes. This PR (fixes #114) threads `DryRun` through the SDK and CLI so the update pipeline resolves manifests and selects versions but skips all filesystem and sysext mutations, reporting the planned work instead. Users can now safely preview exactly what an update would download, install, and vacuum.

## Changes

- **SDK dry-run support**: Added `DryRun` to `UpdateFeaturesOptions` and the internal `installTransferOptions`. `installTransfer` now returns before downloading when dry-run is set, and `UpdateFeatures` reports would-download/would-install results and skips the batched sysext refresh.
- **Read-only vacuum planning**: Refactored `sysext` vacuum logic into a shared `planVacuum` helper and added the exported `PlanVacuumAfterInstall`, which previews removed/kept versions (including a not-yet-installed active version) without deleting files.
- **Result reporting**: Extended `UpdateResult` with `DryRun` and `RemovedVersions` fields so callers can see planned installs and vacuum removals in both text and JSON output.
- **CLI wiring**: `features update` now passes `clix.DryRun` into the SDK, prints a `[DRY RUN]` header, and shows a `would download` status. Extracted `getEUID` for testable root checks.
- **Tests**: Added SDK and CLI tests verifying dry-run threads correctly and performs no downloads, symlink creation, sysext linking, refresh, or vacuum deletion.
- **Docs**: Updated `README.md`, `CLAUDE.md`, `yeti/OVERVIEW.md`, `yeti/sdk-api.md`, and the command help text to document dry-run behavior and the new vacuum-planning helper.