### PR TITLE
docs: update documentation for updex

### DIFF
--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -71,7 +71,14 @@ CLI (cmd/daemon.go) → systemd (direct, bypasses SDK)
 
 - Text tables by default, JSON with `--json` flag — both `--json` and `--dry-run` are provided by the `github.com/frostyard/clix` package, not defined in this repo
 - `cmd/updex/client.go` always wires `clix.NewReporter()` and `newProgressBar`; there is no repo-defined `--quiet` flag in the current code
-- Operations requiring filesystem changes call `requireRoot()` to enforce root access
+- Operations requiring filesystem changes call `requireRoot()` before entering the SDK. This currently includes dry-run variants of `features enable`, `features disable`, and `features update`, so dry-run is mutation-free but not rootless from the CLI.
+
+### Dry-run behavior
+
+- `UpdateFeaturesOptions.DryRun` is threaded through `UpdateFeatures` into `installTransfer`, which is the choke point before downloads, symlink updates, `/var/lib/extensions` linking, refresh, and vacuum deletion
+- Update dry-runs still perform read-only work: load configs, fetch manifests, resolve versions, inspect installed files, and, unless `NoVacuum` is set, call `sysext.PlanVacuumAfterInstall` to populate `UpdateResult.RemovedVersions`
+- In update dry-run results, `Downloaded=true` means "would download", `Installed=false` means no install occurred, and `DryRun=true` disambiguates the status for JSON consumers
+- Enable/disable dry-runs are lighter previews: enabling with `--now` lists associated transfer components without manifest/version resolution, while disabling with `--now` performs active-version checks but records component-level "would remove" entries rather than enumerating every file
 
 ### Public API (Issue #13)
 
@@ -183,6 +190,8 @@ Global flags:
   --dry-run                             Preview without modifying filesystem (from clix)
   --verbose                             Enable debug output (from clix)
 ```
+
+Mutating commands enforce root before reading `--dry-run`, so examples that preview `features enable`, `features disable`, or `features update` may still need `sudo` when run through the CLI.
 
 ## Dependencies
 

--- a/yeti/sdk-api.md
+++ b/yeti/sdk-api.md
@@ -41,6 +41,8 @@ func (c *Client) DisableFeature(ctx context.Context, name string, opts DisableFe
 
 Enable creates a drop-in file setting `Enabled=true`. With `Now: true`, it downloads extensions via the shared `installTransfer` pipeline. Disable creates a drop-in setting `Enabled=false`.
 
+In dry-run mode, enable/disable skip writing drop-ins and skip sysext/filesystem mutations. `EnableFeature` with `Now: true` records associated transfer components as would-download entries without fetching manifests or resolving exact versions. `DisableFeature` with `Now: true` still checks active versions for force-safety, then records component-level would-remove entries instead of deleting files.
+
 **EnableFeatureOptions:**
 | Field | Type | Description |
 |-------|------|-------------|
@@ -64,10 +66,12 @@ func (c *Client) UpdateFeatures(ctx context.Context, opts UpdateFeaturesOptions)
 
 Downloads and installs the newest available version for each enabled feature's transfers. Delegates per-component work to the internal `installTransfer` pipeline (which handles download, symlink, sysext linking, and vacuum). Manifests are cached by source URL — transfers sharing the same source avoid redundant HTTP requests. Parsed source patterns are returned from version listing and reused by the install pipeline to avoid redundant pattern compilation. Refresh is batched — a single `systemd-sysext refresh` runs after all components are processed. With `DryRun: true`, manifests are fetched and versions are selected, but download, symlink update, sysext linking, refresh, and vacuum deletion are skipped. Returns per-feature results with per-component status.
 
+Dry-run update results use the normal `UpdateResult` shape: `Downloaded=true` means the component would be downloaded, `Installed=false` means no install happened, and `RemovedVersions` is populated from `sysext.PlanVacuumAfterInstall` unless `NoVacuum` is true. The CLI still enforces root before calling this SDK method, but the SDK method itself is read-only in dry-run mode apart from remote manifest fetches.
+
 **UpdateFeaturesOptions:**
 | Field | Type | Description |
 |-------|------|-------------|
-| `DryRun` | `bool` | Preview downloads, installs, refreshes, and vacuum removals without modifying filesystem or sysext state |
+| `DryRun` | `bool` | Preview downloads, installs, refreshes, and vacuum removals without modifying filesystem or sysext state; still fetches manifests and inspects local installed files |
 | `NoRefresh` | `bool` | Skip `systemd-sysext refresh` after updates |
 | `NoVacuum` | `bool` | Skip removing old versions |
 
@@ -134,7 +138,7 @@ type UpdateResult struct {
 }
 ```
 
-For dry-run update results, `Downloaded=true` means the component would be downloaded, `Installed=false` means no install was performed, and `RemovedVersions` lists versions vacuum would remove if `NoVacuum` is false.
+For dry-run update results, `Downloaded=true` means the component would be downloaded, `Installed=false` means no install was performed, and `RemovedVersions` lists versions vacuum would remove if `NoVacuum` is false. Non-dry-run `RemovedVersions` is currently not populated because `installTransfer` calls `sysext.Vacuum` rather than `VacuumWithDetails`.
 
 ### CheckFeaturesResult / CheckResult
 


### PR DESCRIPTION
## Summary

This PR updates the AI-facing documentation to clarify current dry-run behavior across the CLI and SDK. It documents where dry-run remains read-only, where the CLI still requires root before invoking SDK methods, and how update result fields should be interpreted by JSON/API consumers.

## Changes

- Added a new dry-run behavior section to `yeti/OVERVIEW.md`.
- Clarified that CLI mutation commands still call `requireRoot()` for dry-run variants of `features enable`, `features disable`, and `features update`.
- Documented what update dry-runs still do: config loading, manifest fetching, version resolution, installed-file inspection, and vacuum planning.
- Expanded `yeti/sdk-api.md` dry-run notes for `EnableFeature`, `DisableFeature`, and `UpdateFeatures`.
- Clarified dry-run `UpdateResult` semantics, including `Downloaded`, `Installed`, `DryRun`, and `RemovedVersions`.
- Noted that non-dry-run `RemovedVersions` is currently not populated because the install path calls `sysext.Vacuum` rather than `VacuumWithDetails`.