### PR TITLE
fix: resolve #123 — [yeti-test] Retry transient download failures with backoff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,8 @@ Key packages:
 - `updex/` — Public SDK: `Client` struct with `Features()`, `EnableFeature()`, `DisableFeature()`, `UpdateFeatures()`, `CheckFeatures()`
 - `cmd/updex/` — Cobra command handlers calling SDK methods (flags, output formatting, progress bars)
 - `config/` — Parses `.transfer` and `.feature` INI files from systemd-style search paths
-- `download/` — HTTP downloads with SHA256 verification and decompression (xz, gz, zstd)
-- `manifest/` — Fetches/parses SHA256SUMS manifests with optional GPG verification
+- `download/` — HTTP downloads with bounded retry for transient failures, SHA256 verification, and decompression (xz, gz, zstd)
+- `manifest/` — Fetches/parses SHA256SUMS manifests with bounded retry for transient failures and optional GPG verification
 - `version/` — Pattern matching (`@v` placeholder) and semantic version comparison
 - `sysext/` — systemd-sysext integration with mockable `Runner` interface and read-only vacuum planning helpers
 - `systemd/` — Generates/installs systemd timer+service units, mockable `Runner` interface

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Designed for systems like Debian Trixie that don't ship with `systemd-sysupdate`
 - Feature-based management of sysext images (enable/disable groups of transfers)
 - Download sysext images from remote HTTP sources
 - SHA256 hash verification via `SHA256SUMS` manifests
+- Bounded retry with exponential backoff for transient network failures and HTTP 5xx/429 responses
 - Optional GPG signature verification (`--verify`)
 - Automatic decompression (xz, gz, zstd)
 - Version management with configurable retention (`InstancesMax`)
@@ -132,6 +133,8 @@ type ClientConfig struct {
     HTTPClient         *http.Client          // Optional shared HTTP client
 }
 ```
+
+Manifest fetches and file downloads retry transient request/body-read failures and HTTP 5xx/429 responses up to three total attempts by default. HTTP 4xx responses other than 429 and checksum mismatches fail immediately. `OnDownloadProgress` may be called once per retry attempt; return a fresh writer each time to avoid double-counting progress.
 
 ### Option Structs
 
@@ -371,6 +374,8 @@ i9j0k1l2...  myext_1.2.0.raw.xz
 ```
 
 For GPG verification, also provide `SHA256SUMS.gpg` (detached signature).
+
+Fetching `SHA256SUMS` retries transient network failures and HTTP 5xx/429 responses with exponential backoff. The detached signature fetch is verified after the manifest body is fetched.
 
 ## JSON Output
 

--- a/download/download.go
+++ b/download/download.go
@@ -10,84 +10,136 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/frostyard/updex/internal/retry"
 )
 
 // ProgressFunc is called before downloading begins with the response content
 // length (-1 if unknown). It returns an io.Writer that will receive downloaded
 // bytes for progress tracking. Return nil to disable progress tracking.
+// Retries call ProgressFunc once per attempt, so implementations should return
+// a fresh independent writer each time to avoid double-counting progress.
 type ProgressFunc func(contentLength int64) io.Writer
+
+type retrySettings struct {
+	cfg    retry.Config
+	notify retry.Notify
+}
+
+// Option configures download behavior.
+type Option func(*retrySettings)
+
+// WithRetryConfig configures bounded retry attempts and base backoff delay.
+func WithRetryConfig(maxAttempts int, baseDelay time.Duration) Option {
+	return func(settings *retrySettings) {
+		settings.cfg = retry.Config{
+			MaxAttempts: maxAttempts,
+			BaseDelay:   baseDelay,
+		}
+	}
+}
+
+// WithRetryNotify configures a callback called before retry backoff sleeps.
+func WithRetryNotify(fn func(attempt, maxAttempts int, reason error)) Option {
+	return func(settings *retrySettings) {
+		settings.notify = retry.Notify(fn)
+	}
+}
+
+func resolveRetry(opts ...Option) retrySettings {
+	settings := retrySettings{cfg: retry.DefaultConfig}
+	for _, opt := range opts {
+		opt(&settings)
+	}
+	return settings
+}
 
 // Download fetches a file from URL, verifies its hash, decompresses if needed,
 // and atomically writes it to the target path. If httpClient is nil, a default
 // client with a 10-minute timeout is used. If onProgress is non-nil, it is
 // called with the content length after the HTTP response is received, and the
 // returned writer receives downloaded bytes for progress tracking.
-func Download(ctx context.Context, httpClient *http.Client, url, targetPath, expectedHash string, mode uint32, onProgress ProgressFunc) error {
+func Download(ctx context.Context, httpClient *http.Client, url, targetPath, expectedHash string, mode uint32, onProgress ProgressFunc, opts ...Option) error {
 	// Create target directory if needed
 	targetDir := filepath.Dir(targetPath)
 	if err := os.MkdirAll(targetDir, 0755); err != nil {
 		return fmt.Errorf("failed to create target directory: %w", err)
 	}
 
-	// Create temporary file in same directory for atomic rename
-	tmpFile, err := os.CreateTemp(targetDir, ".updex-download-*")
-	if err != nil {
-		return fmt.Errorf("failed to create temp file: %w", err)
-	}
-	tmpPath := tmpFile.Name()
-	defer func() {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpPath) // Clean up on failure
-	}()
-
-	// Download the file
 	if httpClient == nil {
 		httpClient = &http.Client{
 			Timeout: 10 * time.Minute,
 		}
 	}
+	rs := resolveRetry(opts...)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to download: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("download failed with status: %s", resp.Status)
-	}
-
-	// Compute hash while downloading
-	hasher := sha256.New()
-	reader := io.TeeReader(resp.Body, hasher)
-
-	// Write to temp file with optional progress
-	var dst io.Writer = tmpFile
-	if onProgress != nil {
-		if pw := onProgress(resp.ContentLength); pw != nil {
-			dst = io.MultiWriter(tmpFile, pw)
+	var tmpPath string
+	err := retry.Do(ctx, rs.cfg, rs.notify, func() error {
+		tmpFile, err := os.CreateTemp(targetDir, ".updex-download-*")
+		if err != nil {
+			return fmt.Errorf("failed to create temp file: %w", err)
 		}
-	}
-	_, err = io.Copy(dst, reader)
+		attemptPath := tmpFile.Name()
+		keepTemp := false
+		defer func() {
+			_ = tmpFile.Close()
+			if !keepTemp {
+				_ = os.Remove(attemptPath)
+			}
+		}()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return fmt.Errorf("failed to create request: %w", err)
+		}
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return retry.TransientIfNetwork(fmt.Errorf("failed to download: %w", err))
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= http.StatusInternalServerError {
+			return retry.Transient(fmt.Errorf("download failed with status: %s", resp.Status))
+		}
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("download failed with status: %s", resp.Status)
+		}
+
+		// Compute hash while downloading
+		hasher := sha256.New()
+		reader := io.TeeReader(resp.Body, hasher)
+
+		// Write to temp file with optional progress
+		var dst io.Writer = tmpFile
+		if onProgress != nil {
+			if pw := onProgress(resp.ContentLength); pw != nil {
+				dst = io.MultiWriter(tmpFile, pw)
+			}
+		}
+		if _, err := io.Copy(dst, reader); err != nil {
+			return retry.TransientIfNetwork(fmt.Errorf("failed to write file: %w", err))
+		}
+
+		// Verify hash of compressed file
+		actualHash := fmt.Sprintf("%x", hasher.Sum(nil))
+		if actualHash != strings.ToLower(expectedHash) {
+			return fmt.Errorf("hash mismatch: expected %s, got %s", expectedHash, actualHash)
+		}
+
+		// Close temp file before decompression
+		if err := tmpFile.Close(); err != nil {
+			return fmt.Errorf("failed to close temp file: %w", err)
+		}
+
+		tmpPath = attemptPath
+		keepTemp = true
+		return nil
+	})
 	if err != nil {
-		return fmt.Errorf("failed to write file: %w", err)
+		return err
 	}
-
-	// Verify hash of compressed file
-	actualHash := fmt.Sprintf("%x", hasher.Sum(nil))
-	if actualHash != strings.ToLower(expectedHash) {
-		return fmt.Errorf("hash mismatch: expected %s, got %s", expectedHash, actualHash)
-	}
-
-	// Close temp file before decompression
-	if err := tmpFile.Close(); err != nil {
-		return fmt.Errorf("failed to close temp file: %w", err)
-	}
+	defer func() { _ = os.Remove(tmpPath) }()
 
 	// Determine if decompression is needed and get final path
 	finalPath := targetPath

--- a/download/download_test.go
+++ b/download/download_test.go
@@ -1,0 +1,131 @@
+package download
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDownloadRetriesServerErrorThenSucceeds(t *testing.T) {
+	content := []byte("download content")
+	expectedHash := hashString(content)
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests.Add(1) <= 2 {
+			http.Error(w, "temporary failure", http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write(content)
+	}))
+	defer server.Close()
+
+	targetPath := filepath.Join(t.TempDir(), "feature.raw")
+	err := Download(t.Context(), server.Client(), server.URL+"/feature.raw", targetPath, expectedHash, 0644, nil, WithRetryConfig(3, time.Millisecond))
+	if err != nil {
+		t.Fatalf("Download() error = %v", err)
+	}
+	if requests.Load() != 3 {
+		t.Fatalf("requests = %d, want 3", requests.Load())
+	}
+	got, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("content = %q, want %q", got, content)
+	}
+}
+
+func TestDownloadDoesNotRetryNotFound(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	targetPath := filepath.Join(t.TempDir(), "feature.raw")
+	err := Download(t.Context(), server.Client(), server.URL+"/feature.raw", targetPath, hashString([]byte("unused")), 0644, nil, WithRetryConfig(3, time.Millisecond))
+	if err == nil {
+		t.Fatal("Download() error = nil, want error")
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("requests = %d, want 1", requests.Load())
+	}
+}
+
+func TestDownloadDoesNotRetryChecksumMismatch(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		_, _ = w.Write([]byte("different content"))
+	}))
+	defer server.Close()
+
+	targetPath := filepath.Join(t.TempDir(), "feature.raw")
+	err := Download(t.Context(), server.Client(), server.URL+"/feature.raw", targetPath, hashString([]byte("expected content")), 0644, nil, WithRetryConfig(3, time.Millisecond))
+	if err == nil {
+		t.Fatal("Download() error = nil, want error")
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("requests = %d, want 1", requests.Load())
+	}
+}
+
+func TestDownloadRetriesTruncatedBodyThenSucceeds(t *testing.T) {
+	content := []byte("complete download content")
+	expectedHash := hashString(content)
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests.Add(1) <= 2 {
+			w.Header().Set("Content-Length", fmt.Sprint(len(content)+10))
+			_, _ = w.Write(content[:len(content)/2])
+			return
+		}
+		_, _ = w.Write(content)
+	}))
+	defer server.Close()
+
+	targetPath := filepath.Join(t.TempDir(), "feature.raw")
+	err := Download(t.Context(), server.Client(), server.URL+"/feature.raw", targetPath, expectedHash, 0644, nil, WithRetryConfig(3, time.Millisecond))
+	if err != nil {
+		t.Fatalf("Download() error = %v", err)
+	}
+	if requests.Load() != 3 {
+		t.Fatalf("requests = %d, want 3", requests.Load())
+	}
+}
+
+func TestDownloadRetriesTooManyRequestsThenSucceeds(t *testing.T) {
+	content := []byte("download content")
+	expectedHash := hashString(content)
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests.Add(1) == 1 {
+			http.Error(w, "rate limited", http.StatusTooManyRequests)
+			return
+		}
+		_, _ = w.Write(content)
+	}))
+	defer server.Close()
+
+	targetPath := filepath.Join(t.TempDir(), "feature.raw")
+	err := Download(t.Context(), server.Client(), server.URL+"/feature.raw", targetPath, expectedHash, 0644, nil, WithRetryConfig(3, time.Millisecond))
+	if err != nil {
+		t.Fatalf("Download() error = %v", err)
+	}
+	if requests.Load() != 2 {
+		t.Fatalf("requests = %d, want 2", requests.Load())
+	}
+}
+
+func hashString(content []byte) string {
+	sum := sha256.Sum256(content)
+	return fmt.Sprintf("%x", sum)
+}

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -1,0 +1,113 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"syscall"
+	"time"
+)
+
+// Config controls bounded retry behavior.
+type Config struct {
+	MaxAttempts int
+	BaseDelay   time.Duration
+}
+
+// DefaultConfig retries an operation up to three total attempts with a
+// one-second exponential backoff.
+var DefaultConfig = Config{MaxAttempts: 3, BaseDelay: time.Second}
+
+// Notify is called before sleeping for a retry attempt.
+type Notify func(attempt, maxAttempts int, reason error)
+
+type transientError struct {
+	err error
+}
+
+func (e transientError) Error() string {
+	return e.err.Error()
+}
+
+func (e transientError) Unwrap() error {
+	return e.err
+}
+
+// Transient marks err as retryable.
+func Transient(err error) error {
+	if err == nil {
+		return nil
+	}
+	if IsTransient(err) {
+		return err
+	}
+	return transientError{err: err}
+}
+
+// IsTransient reports whether err has been marked retryable.
+func IsTransient(err error) bool {
+	var transient transientError
+	return errors.As(err, &transient)
+}
+
+// TransientIfNetwork marks err retryable only when it looks like a transient
+// network or response-body read failure.
+func TransientIfNetwork(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return Transient(err)
+	}
+
+	switch {
+	case errors.Is(err, syscall.ECONNRESET),
+		errors.Is(err, syscall.ECONNREFUSED),
+		errors.Is(err, syscall.ECONNABORTED),
+		errors.Is(err, syscall.EPIPE),
+		errors.Is(err, io.EOF),
+		errors.Is(err, io.ErrUnexpectedEOF):
+		return Transient(err)
+	default:
+		return err
+	}
+}
+
+// Do runs fn until it succeeds, returns a non-transient error, exhausts the
+// configured attempts, or ctx is canceled while waiting for the next attempt.
+func Do(ctx context.Context, cfg Config, notify Notify, fn func() error) error {
+	if cfg.MaxAttempts <= 0 {
+		cfg.MaxAttempts = DefaultConfig.MaxAttempts
+	}
+	if cfg.BaseDelay <= 0 {
+		cfg.BaseDelay = DefaultConfig.BaseDelay
+	}
+
+	for attempt := 1; attempt <= cfg.MaxAttempts; attempt++ {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		if !IsTransient(err) || attempt == cfg.MaxAttempts {
+			return err
+		}
+
+		if notify != nil {
+			notify(attempt+1, cfg.MaxAttempts, err)
+		}
+
+		delay := cfg.BaseDelay * (1 << (attempt - 1))
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+
+	return nil
+}

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -1,0 +1,132 @@
+package retry
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type timeoutErr struct{}
+
+func (timeoutErr) Error() string   { return "timeout" }
+func (timeoutErr) Timeout() bool   { return true }
+func (timeoutErr) Temporary() bool { return true }
+
+func TestDoSucceedsAfterTransientFailures(t *testing.T) {
+	var calls int
+	var notified []int
+	err := Do(t.Context(), Config{MaxAttempts: 3, BaseDelay: time.Millisecond}, func(attempt, maxAttempts int, reason error) {
+		if maxAttempts != 3 {
+			t.Errorf("maxAttempts = %d, want 3", maxAttempts)
+		}
+		if !IsTransient(reason) {
+			t.Errorf("notify reason is not transient: %v", reason)
+		}
+		notified = append(notified, attempt)
+	}, func() error {
+		calls++
+		if calls < 3 {
+			return Transient(fmt.Errorf("temporary failure %d", calls))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("calls = %d, want 3", calls)
+	}
+	if fmt.Sprint(notified) != "[2 3]" {
+		t.Fatalf("notified attempts = %v, want [2 3]", notified)
+	}
+}
+
+func TestDoStopsAfterMaxAttempts(t *testing.T) {
+	var calls int
+	var notifications int
+	err := Do(t.Context(), Config{MaxAttempts: 3, BaseDelay: time.Millisecond}, func(int, int, error) {
+		notifications++
+	}, func() error {
+		calls++
+		return Transient(errors.New("temporary failure"))
+	})
+	if err == nil {
+		t.Fatal("Do() error = nil, want error")
+	}
+	if calls != 3 {
+		t.Fatalf("calls = %d, want 3", calls)
+	}
+	if notifications != 2 {
+		t.Fatalf("notifications = %d, want 2", notifications)
+	}
+}
+
+func TestDoStopsOnNonTransientError(t *testing.T) {
+	var calls int
+	var notifications int
+	wantErr := errors.New("permanent failure")
+	err := Do(t.Context(), Config{MaxAttempts: 3, BaseDelay: time.Millisecond}, func(int, int, error) {
+		notifications++
+	}, func() error {
+		calls++
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Do() error = %v, want %v", err, wantErr)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
+	}
+	if notifications != 0 {
+		t.Fatalf("notifications = %d, want 0", notifications)
+	}
+}
+
+func TestDoContextCanceledDuringBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := Do(ctx, Config{MaxAttempts: 3, BaseDelay: time.Hour}, nil, func() error {
+		return Transient(errors.New("temporary failure"))
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Do() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestTransientIfNetwork(t *testing.T) {
+	certErr := &tls.CertificateVerificationError{
+		UnverifiedCertificates: []*x509.Certificate{{}},
+		Err:                    errors.New("bad certificate"),
+	}
+
+	tests := []struct {
+		name      string
+		err       error
+		transient bool
+	}{
+		{name: "timeout", err: timeoutErr{}, transient: true},
+		{name: "connection reset", err: syscall.ECONNRESET, transient: true},
+		{name: "connection refused", err: syscall.ECONNREFUSED, transient: true},
+		{name: "unexpected eof", err: io.ErrUnexpectedEOF, transient: true},
+		{name: "certificate verification", err: certErr, transient: false},
+		{name: "unsupported protocol", err: &url.Error{Op: "Get", URL: "bogus://example", Err: errors.New("unsupported protocol scheme")}, transient: false},
+		{name: "plain error", err: errors.New("plain error"), transient: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := TransientIfNetwork(tt.err)
+			if IsTransient(err) != tt.transient {
+				t.Fatalf("IsTransient(%v) = %v, want %v", err, IsTransient(err), tt.transient)
+			}
+		})
+	}
+}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/frostyard/updex/internal/retry"
 )
 
 // Manifest represents a parsed SHA256SUMS manifest
@@ -18,38 +20,81 @@ type Manifest struct {
 	Files map[string]string // filename -> SHA256 hash
 }
 
+type retrySettings struct {
+	cfg    retry.Config
+	notify retry.Notify
+}
+
+// Option configures manifest fetch behavior.
+type Option func(*retrySettings)
+
+// WithRetryConfig configures bounded retry attempts and base backoff delay.
+func WithRetryConfig(maxAttempts int, baseDelay time.Duration) Option {
+	return func(settings *retrySettings) {
+		settings.cfg = retry.Config{
+			MaxAttempts: maxAttempts,
+			BaseDelay:   baseDelay,
+		}
+	}
+}
+
+// WithRetryNotify configures a callback called before retry backoff sleeps.
+func WithRetryNotify(fn func(attempt, maxAttempts int, reason error)) Option {
+	return func(settings *retrySettings) {
+		settings.notify = retry.Notify(fn)
+	}
+}
+
+func resolveRetry(opts ...Option) retrySettings {
+	settings := retrySettings{cfg: retry.DefaultConfig}
+	for _, opt := range opts {
+		opt(&settings)
+	}
+	return settings
+}
+
 // Fetch downloads and parses a SHA256SUMS manifest from the given base URL.
 // If httpClient is nil, a default client with a 30-second timeout is used.
 // If verify is true, it will also verify the GPG signature.
-func Fetch(ctx context.Context, httpClient *http.Client, baseURL string, verify bool) (*Manifest, error) {
+func Fetch(ctx context.Context, httpClient *http.Client, baseURL string, verify bool, opts ...Option) (*Manifest, error) {
 	manifestURL := strings.TrimRight(baseURL, "/") + "/SHA256SUMS"
 
-	// Download manifest
 	if httpClient == nil {
 		httpClient = &http.Client{
 			Timeout: 30 * time.Second,
 		}
 	}
+	rs := resolveRetry(opts...)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, manifestURL, nil)
+	var content []byte
+	err := retry.Do(ctx, rs.cfg, rs.notify, func() error {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, manifestURL, nil)
+		if err != nil {
+			return fmt.Errorf("failed to create request: %w", err)
+		}
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return retry.TransientIfNetwork(fmt.Errorf("failed to fetch manifest: %w", err))
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= http.StatusInternalServerError {
+			return retry.Transient(fmt.Errorf("manifest fetch failed with status: %s", resp.Status))
+		}
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("manifest fetch failed with status: %s", resp.Status)
+		}
+
+		content, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return retry.TransientIfNetwork(fmt.Errorf("failed to read manifest: %w", err))
+		}
+
+		return nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch manifest: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("manifest fetch failed with status: %s", resp.Status)
-	}
-
-	// Read manifest content
-	content, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read manifest: %w", err)
+		return nil, err
 	}
 
 	// Verify GPG signature if requested

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -4,9 +4,13 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestParseManifest(t *testing.T) {
@@ -236,4 +240,86 @@ func TestHashVerifyReaderPartialReads(t *testing.T) {
 	if err := reader.Verify(); err != nil {
 		t.Errorf("Verify() after partial reads error = %v", err)
 	}
+}
+
+func TestFetchRetriesServerErrorThenSucceeds(t *testing.T) {
+	content := validManifestContent()
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/SHA256SUMS" {
+			http.NotFound(w, r)
+			return
+		}
+		if requests.Add(1) <= 2 {
+			http.Error(w, "temporary failure", http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte(content))
+	}))
+	defer server.Close()
+
+	m, err := Fetch(t.Context(), server.Client(), server.URL, false, WithRetryConfig(3, time.Millisecond))
+	if err != nil {
+		t.Fatalf("Fetch() error = %v", err)
+	}
+	if requests.Load() != 3 {
+		t.Fatalf("requests = %d, want 3", requests.Load())
+	}
+	if got := m.Files["file.raw"]; got != testManifestHash() {
+		t.Fatalf("Files[file.raw] = %q, want %q", got, testManifestHash())
+	}
+}
+
+func TestFetchDoesNotRetryNotFound(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	_, err := Fetch(t.Context(), server.Client(), server.URL, false, WithRetryConfig(3, time.Millisecond))
+	if err == nil {
+		t.Fatal("Fetch() error = nil, want error")
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("requests = %d, want 1", requests.Load())
+	}
+}
+
+func TestFetchRetriesTruncatedBodyThenSucceeds(t *testing.T) {
+	content := validManifestContent()
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/SHA256SUMS" {
+			http.NotFound(w, r)
+			return
+		}
+		if requests.Add(1) <= 2 {
+			w.Header().Set("Content-Length", fmt.Sprint(len(content)+10))
+			_, _ = w.Write([]byte(content[:len(content)/2]))
+			return
+		}
+		_, _ = w.Write([]byte(content))
+	}))
+	defer server.Close()
+
+	m, err := Fetch(t.Context(), server.Client(), server.URL, false, WithRetryConfig(3, time.Millisecond))
+	if err != nil {
+		t.Fatalf("Fetch() error = %v", err)
+	}
+	if requests.Load() != 3 {
+		t.Fatalf("requests = %d, want 3", requests.Load())
+	}
+	if got := m.Files["file.raw"]; got != testManifestHash() {
+		t.Fatalf("Files[file.raw] = %q, want %q", got, testManifestHash())
+	}
+}
+
+func validManifestContent() string {
+	return testManifestHash() + "  file.raw\n"
+}
+
+func testManifestHash() string {
+	return "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 }

--- a/updex/install.go
+++ b/updex/install.go
@@ -73,7 +73,7 @@ func (c *Client) installTransfer(ctx context.Context, transfer *config.Transfer,
 	}
 
 	c.debug("downloading %s → %s", downloadURL, targetPath)
-	err = download.Download(ctx, c.httpClient, downloadURL, targetPath, expectedHash, transfer.Target.Mode, c.config.OnDownloadProgress)
+	err = download.Download(ctx, c.httpClient, downloadURL, targetPath, expectedHash, transfer.Target.Mode, c.config.OnDownloadProgress, download.WithRetryNotify(c.retryNotify("download")))
 	if err != nil {
 		return "", nil, false, fmt.Errorf("download failed: %w", err)
 	}

--- a/updex/list.go
+++ b/updex/list.go
@@ -23,7 +23,7 @@ func (c *Client) getAvailableVersions(ctx context.Context, transfer *config.Tran
 		// Fetch manifest
 		c.debug("fetching manifest from %s", transfer.Source.Path)
 		var err error
-		m, err = manifest.Fetch(ctx, c.httpClient, transfer.Source.Path, c.config.Verify || transfer.Transfer.Verify)
+		m, err = manifest.Fetch(ctx, c.httpClient, transfer.Source.Path, c.config.Verify || transfer.Transfer.Verify, manifest.WithRetryNotify(c.retryNotify("manifest fetch")))
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/updex/updex.go
+++ b/updex/updex.go
@@ -61,8 +61,9 @@ type ClientConfig struct {
 	// OnDownloadProgress is an optional callback for download progress tracking.
 	// If non-nil, it is passed to [download.Download] and called with the
 	// response content length (-1 if unknown). The returned io.Writer receives
-	// downloaded bytes. Return nil from the callback to disable progress for
-	// a given download.
+	// downloaded bytes. Retries call this once per attempt, so return a fresh
+	// independent writer each time to avoid double-counting progress. Return
+	// nil from the callback to disable progress for a given download.
 	OnDownloadProgress download.ProgressFunc
 
 	// HTTPClient is an optional HTTP client used for all downloads and manifest
@@ -102,6 +103,12 @@ func (c *Client) msg(format string, a ...any) {
 
 func (c *Client) warn(format string, a ...any) {
 	c.reporter.Warning(format, a...)
+}
+
+func (c *Client) retryNotify(what string) func(attempt, maxAttempts int, reason error) {
+	return func(attempt, maxAttempts int, reason error) {
+		c.warn("retrying %s (attempt %d/%d): %v", what, attempt, maxAttempts, reason)
+	}
 }
 
 func (c *Client) debug(format string, a ...any) {

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -141,11 +141,11 @@ Transfer file values support systemd-style `%` specifiers. See [Configuration Re
 1. Load all `.feature` and `.transfer` files from search paths
 2. Filter transfers to those matching enabled features
 3. For each transfer:
-   - Fetch `SHA256SUMS` manifest from source URL (+ GPG verify if configured); manifests are cached by source URL across transfers so that multiple transfers sharing the same source make only one HTTP request
+   - Fetch `SHA256SUMS` manifest from source URL (+ GPG verify if configured); transient network failures during request or body read and HTTP 5xx/429 are retried up to 3 attempts with exponential backoff, while TLS/cert errors, unsupported protocols, 4xx other than 429, and checksum mismatches fail immediately. Manifests are cached by source URL across transfers so that multiple transfers sharing the same source make only one HTTP request
    - Parse source patterns and extract available versions using pattern matching (`@v` placeholder); parsed patterns are returned to callers so `installTransfer` reuses them without re-parsing
    - Select newest version via `version.Sort` (semver where possible, Debian/dpkg ordering for versions with `:` or `~`, string fallback otherwise)
    - Skip if already installed (check target directory)
-   - Download file, verify SHA256 hash of compressed bytes during transfer
+   - Download file, retrying the same transient request/body-read failures and HTTP 5xx/429 from scratch without range/resume requests, then verify SHA256 hash of compressed bytes during transfer
    - Decompress if needed (xz, gz, zstd — detected from filename)
    - Atomically rename to final path, update `CurrentSymlink`
    - Create symlink in `/var/lib/extensions/` pointing to extension

--- a/yeti/sdk-api.md
+++ b/yeti/sdk-api.md
@@ -20,7 +20,7 @@ type ClientConfig struct {
 func NewClient(cfg ClientConfig) *Client
 ```
 
-`NewClient` stores the provided `SysextRunner` directly on the `Client` struct. If `SysextRunner` is nil, it defaults to `&sysext.DefaultRunner{}`. If `Progress` is nil, it defaults to `reporter.NoopReporter{}`. `OnDownloadProgress` is passed through to `download.Download` calls — when non-nil, it is called with the HTTP response content length (-1 if unknown) and should return an `io.Writer` that receives downloaded bytes for progress tracking (return nil to skip progress for that download). If `HTTPClient` is nil, a default `http.Client` with a 10-minute timeout is created and reused for all manifest fetches and file downloads, enabling HTTP keep-alive connection reuse. The client stores the original config and does not mutate global package state.
+`NewClient` stores the provided `SysextRunner` directly on the `Client` struct. If `SysextRunner` is nil, it defaults to `&sysext.DefaultRunner{}`. If `Progress` is nil, it defaults to `reporter.NoopReporter{}`. `OnDownloadProgress` is passed through to `download.Download` calls — when non-nil, it is called with the HTTP response content length (-1 if unknown) and should return an `io.Writer` that receives downloaded bytes for progress tracking (return nil to skip progress for that download). Retries call this callback once per attempt, so implementations must return a fresh independent writer each time to avoid double-counting progress. If `HTTPClient` is nil, a default `http.Client` with a 10-minute timeout is created and reused for all manifest fetches and file downloads, enabling HTTP keep-alive connection reuse. The client stores the original config and does not mutate global package state.
 
 ## Methods
 
@@ -169,14 +169,14 @@ type CheckResult struct {
 
 ### `manifest`
 
-- `Fetch(ctx context.Context, httpClient *http.Client, baseURL string, verify bool) (*Manifest, error)` — Fetch and parse `SHA256SUMS` from URL. If `httpClient` is nil, a default client with a 30-second timeout is used
+- `Fetch(ctx context.Context, httpClient *http.Client, baseURL string, verify bool, opts ...Option) (*Manifest, error)` — Fetch and parse `SHA256SUMS` from URL. If `httpClient` is nil, a default client with a 30-second timeout is used. The `SHA256SUMS` GET and body read retry transient network failures and HTTP 5xx/429 up to 3 total attempts with exponential backoff; TLS/cert errors, unsupported protocols, and 4xx other than 429 fail immediately. `WithRetryConfig(maxAttempts int, baseDelay time.Duration)` overrides retry bounds for tests or SDK consumers; `WithRetryNotify(func(attempt, maxAttempts int, reason error))` reports retry attempts
 - `VerifyHash(filePath string, expectedHash string) error` — Verify a file's SHA256
 - `VerifyHashReader(r io.Reader, expectedHash string) *HashVerifyReader` — Streaming hash verification
 
 ### `download`
 
-- `Download(ctx context.Context, httpClient *http.Client, url, targetPath, expectedHash string, mode uint32, onProgress ProgressFunc) error` — Download with hash verification (on compressed bytes) and auto-decompression. Uses atomic rename (falls back to atomic copy on cross-device). If `httpClient` is nil, a default client with a 10-minute timeout is used. Default mode: `0644` if `mode == 0`. `onProgress` is called with the response content length; the returned `io.Writer` receives downloaded bytes. Pass nil to disable progress tracking
-- `ProgressFunc` — `func(contentLength int64) io.Writer` callback type for download progress
+- `Download(ctx context.Context, httpClient *http.Client, url, targetPath, expectedHash string, mode uint32, onProgress ProgressFunc, opts ...Option) error` — Download with hash verification (on compressed bytes) and auto-decompression. Uses atomic rename (falls back to atomic copy on cross-device). If `httpClient` is nil, a default client with a 10-minute timeout is used. Default mode: `0644` if `mode == 0`. GETs and response-body reads retry transient network failures and HTTP 5xx/429 up to 3 total attempts with exponential backoff; each retry re-requests the file from scratch. 4xx other than 429 and checksum mismatches fail immediately. `WithRetryConfig(maxAttempts int, baseDelay time.Duration)` overrides retry bounds for tests or SDK consumers; `WithRetryNotify(func(attempt, maxAttempts int, reason error))` reports retry attempts
+- `ProgressFunc` — `func(contentLength int64) io.Writer` callback type for download progress. It may be called once per retry attempt, and should return a fresh independent writer each time to avoid double-counting
 - `DecompressReader(r io.Reader, compressionType string) (io.ReadCloser, error)` — Returns a decompressing reader for `"xz"`, `"gz"`, `"zstd"`, or passthrough for `""`
 
 ### `version`


### PR DESCRIPTION
## Summary

Adds bounded retry with exponential backoff for transient failures during unattended updex downloads and SHA256SUMS manifest fetches. This prevents a single temporary network issue, HTTP 5xx, or 429 response from failing an entire update pass while still failing immediately for permanent errors like most 4xx responses and checksum mismatches.

## Changes

- Added shared internal retry support with default 3 total attempts and exponential backoff.
- Updated file downloads to retry transient request/body-read failures and HTTP 5xx/429 responses from scratch.
- Updated manifest fetching to use the same retry behavior before parsing or optional GPG verification.
- Added retry notifications through the existing reporter, including attempt count and failure reason.
- Documented retry behavior and progress callback expectations.
- Added unit tests for retry success, no-retry 404 behavior, checksum mismatch behavior, truncated bodies, 429 responses, and retry helper behavior.

Closes #123