### PR TITLE
fix: deterministic version selection for '+'-encoded Debian versions and decompressed target filenames

### DIFF
--- a/download/decompress_test.go
+++ b/download/decompress_test.go
@@ -278,3 +278,23 @@ func TestDecompressFileNonexistentSource(t *testing.T) {
 		t.Error("expected error for nonexistent source file")
 	}
 }
+
+func TestStripCompressionSuffix(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"foo_1.0.raw.zst", "foo_1.0.raw"},
+		{"foo_1.0.raw.zstd", "foo_1.0.raw"},
+		{"foo_1.0.raw.xz", "foo_1.0.raw"},
+		{"foo_1.0.raw.gz", "foo_1.0.raw"},
+		{"foo_1.0.raw", "foo_1.0.raw"},
+		{"foo_1.0.RAW.ZST", "foo_1.0.RAW"},
+	}
+
+	for _, tt := range tests {
+		if got := StripCompressionSuffix(tt.in); got != tt.want {
+			t.Errorf("StripCompressionSuffix(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/download/download.go
+++ b/download/download.go
@@ -192,6 +192,24 @@ func detectCompression(filename string) string {
 	}
 }
 
+// compressionSuffixes lists the filename suffixes Download decompresses,
+// longest first so ".zstd" is stripped before ".zst" can match.
+var compressionSuffixes = []string{".zstd", ".zst", ".xz", ".gz"}
+
+// StripCompressionSuffix removes a trailing compression suffix (.xz, .gz,
+// .zst, .zstd) from a filename. Download always stores files decompressed, so
+// installed filenames must not carry a compression suffix; use this to derive
+// the on-disk name from a pattern that includes one.
+func StripCompressionSuffix(filename string) string {
+	lower := strings.ToLower(filename)
+	for _, suffix := range compressionSuffixes {
+		if strings.HasSuffix(lower, suffix) {
+			return filename[:len(filename)-len(suffix)]
+		}
+	}
+	return filename
+}
+
 // copyFile atomically copies a file with the given mode. It writes to a temp
 // file on the destination device, syncs to disk, then renames into place.
 func copyFile(src, dst string, mode os.FileMode) error {

--- a/updex/install.go
+++ b/updex/install.go
@@ -54,15 +54,10 @@ func (c *Client) installTransfer(ctx context.Context, transfer *config.Transfer,
 		return "", nil, false, fmt.Errorf("no file found for version %s", versionToInstall)
 	}
 
-	// Build target path using first target pattern
-	targetPatterns := transfer.Target.Patterns()
-
-	targetPattern, err := version.ParsePattern(targetPatterns[0])
+	targetFile, err := buildTargetFilename(transfer.Target.Patterns(), versionToInstall)
 	if err != nil {
-		return "", nil, false, fmt.Errorf("invalid target pattern: %w", err)
+		return "", nil, false, err
 	}
-
-	targetFile := targetPattern.BuildFilename(versionToInstall)
 	targetPath := filepath.Join(transfer.Target.Path, targetFile)
 
 	// Download
@@ -108,4 +103,36 @@ func (c *Client) installTransfer(ctx context.Context, transfer *config.Transfer,
 	}
 
 	return versionToInstall, m, true, nil
+}
+
+// buildTargetFilename derives the installed filename for a version from the
+// target match patterns. Downloads are always stored decompressed, so it
+// prefers the first pattern whose name carries no compression suffix; if every
+// pattern is a compressed variant, it strips the suffix from the first one so
+// the on-disk name matches the actual content.
+func buildTargetFilename(targetPatterns []string, ver string) (string, error) {
+	var fallback string
+	var firstErr error
+	for _, patternStr := range targetPatterns {
+		p, err := version.ParsePattern(patternStr)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		name := p.BuildFilename(ver)
+		if stripped := download.StripCompressionSuffix(name); stripped == name {
+			return name, nil
+		} else if fallback == "" {
+			fallback = stripped
+		}
+	}
+	if fallback != "" {
+		return fallback, nil
+	}
+	if firstErr != nil {
+		return "", fmt.Errorf("invalid target pattern: %w", firstErr)
+	}
+	return "", fmt.Errorf("no target pattern configured")
 }

--- a/updex/install_test.go
+++ b/updex/install_test.go
@@ -1,0 +1,146 @@
+package updex
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/frostyard/updex/internal/testutil"
+	"github.com/frostyard/updex/sysext"
+	"github.com/klauspost/compress/zstd"
+)
+
+// createTransferFileWithPatterns creates a .transfer file with explicit
+// (possibly multi-valued) source and target MatchPattern lines.
+func createTransferFileWithPatterns(t *testing.T, configDir, component, featureName, baseURL, sourcePatterns, targetPatterns string) {
+	t.Helper()
+	content := `[Transfer]
+Features=` + featureName + `
+
+[Source]
+Type=url-file
+Path=` + baseURL + `
+MatchPattern=` + sourcePatterns + `
+
+[Target]
+MatchPattern=` + targetPatterns + `
+CurrentSymlink=` + component + `.raw
+`
+	path := filepath.Join(configDir, component+".transfer")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create transfer file: %v", err)
+	}
+}
+
+// TestUpdateFeatures_TargetFilename_UncompressedSource verifies that when the
+// manifest lists an uncompressed file but the target MatchPattern list starts
+// with a compressed variant, the installed file is named after its actual
+// (uncompressed) content instead of the first target pattern.
+func TestUpdateFeatures_TargetFilename_UncompressedSource(t *testing.T) {
+	configDir := t.TempDir()
+	targetDir := t.TempDir()
+	mockRunner := &sysext.MockRunner{}
+
+	content := []byte("uncompressed raw ddi content")
+	server := testutil.NewTestServer(t, testutil.TestServerFiles{
+		Files: map[string]string{
+			"testext_1.0.0.raw": hashContent(content),
+		},
+		Content: map[string][]byte{
+			"testext_1.0.0.raw": content,
+		},
+	})
+	defer server.Close()
+
+	createFeatureFile(t, configDir, "testfeature", true)
+	createTransferFileWithPatterns(t, configDir, "testext", "testfeature", server.URL,
+		"testext_@v.raw.zst testext_@v.raw",
+		"testext_@v.raw.zst testext_@v.raw")
+	updateTransferTargetPath(t, configDir, targetDir)
+
+	client := NewClient(ClientConfig{Definitions: configDir, SysextRunner: mockRunner})
+	results, err := client.UpdateFeatures(t.Context(), UpdateFeaturesOptions{NoRefresh: true})
+	if err != nil {
+		t.Fatalf("UpdateFeatures failed: %v", err)
+	}
+	if len(results) != 1 || len(results[0].Results) != 1 {
+		t.Fatalf("expected 1 feature result with 1 component, got %+v", results)
+	}
+	if results[0].Results[0].Error != "" {
+		t.Fatalf("component update failed: %s", results[0].Results[0].Error)
+	}
+
+	got, err := os.ReadFile(filepath.Join(targetDir, "testext_1.0.0.raw"))
+	if err != nil {
+		t.Fatalf("expected testext_1.0.0.raw to exist: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("installed file content mismatch: got %q, want %q", got, content)
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, "testext_1.0.0.raw.zst")); !os.IsNotExist(err) {
+		t.Error("expected testext_1.0.0.raw.zst to NOT exist (content is uncompressed)")
+	}
+}
+
+// TestUpdateFeatures_TargetFilename_CompressedSource verifies that a
+// zstd-compressed source file is stored decompressed under a name without the
+// compression suffix.
+func TestUpdateFeatures_TargetFilename_CompressedSource(t *testing.T) {
+	configDir := t.TempDir()
+	targetDir := t.TempDir()
+	mockRunner := &sysext.MockRunner{}
+
+	raw := []byte("raw ddi payload that will be zstd compressed")
+	var buf bytes.Buffer
+	zw, err := zstd.NewWriter(&buf)
+	if err != nil {
+		t.Fatalf("failed to create zstd writer: %v", err)
+	}
+	if _, err := zw.Write(raw); err != nil {
+		t.Fatalf("failed to compress: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("failed to close zstd writer: %v", err)
+	}
+	compressed := buf.Bytes()
+
+	server := testutil.NewTestServer(t, testutil.TestServerFiles{
+		Files: map[string]string{
+			"testext_1.0.0.raw.zst": hashContent(compressed),
+		},
+		Content: map[string][]byte{
+			"testext_1.0.0.raw.zst": compressed,
+		},
+	})
+	defer server.Close()
+
+	createFeatureFile(t, configDir, "testfeature", true)
+	createTransferFileWithPatterns(t, configDir, "testext", "testfeature", server.URL,
+		"testext_@v.raw.zst testext_@v.raw",
+		"testext_@v.raw.zst testext_@v.raw")
+	updateTransferTargetPath(t, configDir, targetDir)
+
+	client := NewClient(ClientConfig{Definitions: configDir, SysextRunner: mockRunner})
+	results, err := client.UpdateFeatures(t.Context(), UpdateFeaturesOptions{NoRefresh: true})
+	if err != nil {
+		t.Fatalf("UpdateFeatures failed: %v", err)
+	}
+	if len(results) != 1 || len(results[0].Results) != 1 {
+		t.Fatalf("expected 1 feature result with 1 component, got %+v", results)
+	}
+	if results[0].Results[0].Error != "" {
+		t.Fatalf("component update failed: %s", results[0].Results[0].Error)
+	}
+
+	got, err := os.ReadFile(filepath.Join(targetDir, "testext_1.0.0.raw"))
+	if err != nil {
+		t.Fatalf("expected testext_1.0.0.raw to exist: %v", err)
+	}
+	if !bytes.Equal(got, raw) {
+		t.Errorf("installed file should be decompressed: got %q, want %q", got, raw)
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, "testext_1.0.0.raw.zst")); !os.IsNotExist(err) {
+		t.Error("expected testext_1.0.0.raw.zst to NOT exist (stored decompressed)")
+	}
+}

--- a/updex/list.go
+++ b/updex/list.go
@@ -3,6 +3,8 @@ package updex
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 
 	"github.com/frostyard/updex/config"
 	"github.com/frostyard/updex/manifest"
@@ -53,10 +55,10 @@ func (c *Client) getAvailableVersions(ctx context.Context, transfer *config.Tran
 		}
 	}
 
-	versions := make([]string, 0, len(versionSet))
-	for v := range versionSet {
-		versions = append(versions, v)
-	}
+	// Sort lexically so the order never depends on map iteration: version.Sort
+	// is stable, so if a comparator gap ever makes two distinct versions compare
+	// equal, selection stays reproducible instead of random.
+	versions := slices.Sorted(maps.Keys(versionSet))
 	c.debug("found %d matching version(s): %v", len(versions), versions)
 
 	return versions, m, patterns, nil

--- a/updex/list_test.go
+++ b/updex/list_test.go
@@ -1,0 +1,47 @@
+package updex
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/frostyard/updex/config"
+	"github.com/frostyard/updex/manifest"
+)
+
+// TestGetAvailableVersions_DeterministicOrder verifies that getAvailableVersions
+// returns versions in a stable order regardless of map iteration order. Combined
+// with the stable version.Sort, this guarantees that a comparator gap (two
+// versions comparing equal) resolves reproducibly instead of randomly.
+func TestGetAvailableVersions_DeterministicOrder(t *testing.T) {
+	client := NewClient(ClientConfig{})
+	transfer := &config.Transfer{
+		Source: config.SourceSection{
+			Type:         "url-file",
+			MatchPattern: "testext_@v.raw",
+		},
+	}
+	m := &manifest.Manifest{
+		Files: map[string]string{
+			"testext_1.0.0.raw": "hash1",
+			"testext_1.0.1.raw": "hash2",
+			"testext_1.1.0.raw": "hash3",
+			"testext_1.2.0.raw": "hash4",
+			"testext_2.0.0.raw": "hash5",
+			"testext_2.1.0.raw": "hash6",
+			"testext_3.0.0.raw": "hash7",
+			"testext_3.1.0.raw": "hash8",
+		},
+	}
+
+	want := []string{"1.0.0", "1.0.1", "1.1.0", "1.2.0", "2.0.0", "2.1.0", "3.0.0", "3.1.0"}
+
+	for range 20 {
+		versions, _, _, err := client.getAvailableVersions(t.Context(), transfer, m)
+		if err != nil {
+			t.Fatalf("getAvailableVersions failed: %v", err)
+		}
+		if !slices.Equal(versions, want) {
+			t.Fatalf("getAvailableVersions returned non-deterministic order: got %v, want %v", versions, want)
+		}
+	}
+}

--- a/version/pattern.go
+++ b/version/pattern.go
@@ -179,11 +179,15 @@ func normalizeVersion(v string) string {
 }
 
 // isDebianVersion reports whether v looks like a Debian/dpkg version string,
-// i.e. it carries an epoch (':') or a tilde ('~'). Tilde is never valid in
-// SemVer, and an explicit epoch is the canonical Debian marker, so either is a
-// reliable signal that semver comparison would be wrong.
+// i.e. it carries an epoch (':'), a tilde ('~'), or a '+'. Tilde is never
+// valid in SemVer and an explicit epoch is the canonical Debian marker. '+'
+// is routed here too: SemVer treats everything after '+' as build metadata
+// and ignores it, which collapses dpkg-derived versions like
+// "1+7.2-debian13-202607011055" (epoch encoded as '+' in sysext image names,
+// where ':' is not filename-safe) to the same precedence — dpkg comparison
+// orders them correctly.
 func isDebianVersion(v string) bool {
-	return strings.ContainsAny(v, "~:")
+	return strings.ContainsAny(v, "~:+")
 }
 
 // compareDebian compares two version strings using Debian/dpkg precedence

--- a/version/pattern_test.go
+++ b/version/pattern_test.go
@@ -296,6 +296,30 @@ func TestCompare(t *testing.T) {
 			want: -1,
 		},
 		{
+			name: "plus-encoded epoch: older timestamp less than newer",
+			v1:   "1+7.2-debian13-202607011055",
+			v2:   "1+7.2-debian13-202607011341",
+			want: -1,
+		},
+		{
+			name: "plus-encoded epoch: newer timestamp greater than older",
+			v1:   "1+7.2-debian13-202607011341",
+			v2:   "1+7.2-debian13-202607011055",
+			want: 1,
+		},
+		{
+			name: "plus-encoded epoch: identical versions equal",
+			v1:   "1+7.2-debian13-202607011055",
+			v2:   "1+7.2-debian13-202607011055",
+			want: 0,
+		},
+		{
+			name: "plus-encoded epoch: higher epoch wins over upstream version",
+			v1:   "2+6.0-debian13-202601010000",
+			v2:   "1+7.2-debian13-202607011341",
+			want: 1,
+		},
+		{
 			name: "v prefix stripped",
 			v1:   "v1.0.0",
 			v2:   "1.0.0",
@@ -663,6 +687,16 @@ func TestSort(t *testing.T) {
 			name:     "date versions",
 			versions: []string{"20240101", "20240115", "20240110"},
 			want:     []string{"20240115", "20240110", "20240101"},
+		},
+		{
+			name:     "plus-encoded debian versions, older first in input",
+			versions: []string{"1+7.2-debian13-202607011055", "1+7.2-debian13-202607011341"},
+			want:     []string{"1+7.2-debian13-202607011341", "1+7.2-debian13-202607011055"},
+		},
+		{
+			name:     "plus-encoded debian versions, newer first in input",
+			versions: []string{"1+7.2-debian13-202607011341", "1+7.2-debian13-202607011055"},
+			want:     []string{"1+7.2-debian13-202607011341", "1+7.2-debian13-202607011055"},
 		},
 		{
 			name:     "single version",

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -93,7 +93,7 @@ All core packages (`config`, `version`, `download`, `manifest`, `sysext`, `syste
 - Every match pattern must contain `@v`; other `@` placeholders match UUIDs, flags, file metadata, and hashes but are not substituted when building target filenames
 - `.transfer` `MatchPattern` fields may contain multiple space-separated alternatives; the first is preserved in `MatchPattern`, while all alternatives are available via `Patterns()`
 - `%` specifiers are expanded at parse time for `Source.MatchPattern`, `Target.MatchPattern`, and `Transfer.ProtectVersion` with a cached context per `LoadTransfers` call. `Source.Path`, `Target.Path`, and `CurrentSymlink` are not currently specifier-expanded.
-- `version.Compare` uses `hashicorp/go-version` for normal semver-like versions, but routes Debian/dpkg-looking versions containing `:` or `~` through a dpkg-compatible comparator so epochs and tildes sort correctly
+- `version.Compare` uses `hashicorp/go-version` for normal semver-like versions, but routes Debian/dpkg-looking versions containing `:`, `~`, or `+` through a dpkg-compatible comparator so epochs and tildes sort correctly. `+` is routed because semver ignores everything after it as build metadata, which collapses dpkg-derived versions like `1+7.2-debian13-<timestamp>` (epoch encoded as `+` in filename-safe sysext image names) to equal precedence
 
 ## Configuration
 
@@ -150,11 +150,11 @@ Transfer file values support systemd-style `%` specifiers. See [Configuration Re
 3. For each transfer:
    - Fetch `SHA256SUMS` manifest from source URL (+ GPG verify if configured); transient network failures during request or body read and HTTP 5xx/429 are retried up to 3 attempts with exponential backoff, while TLS/cert errors, unsupported protocols, 4xx other than 429, and checksum mismatches fail immediately. Manifests are cached by source URL across transfers so that multiple transfers sharing the same source make only one HTTP request
    - The manifest cache key is only the source URL path. Verification is decided during the first fetch for that path; avoid relying on mixed per-transfer `Verify` settings for one shared source URL unless the cache behavior is changed.
-   - Parse source patterns and extract available versions using pattern matching (`@v` placeholder); parsed patterns are returned to callers so `installTransfer` reuses them without re-parsing
-   - Select newest version via `version.Sort` (semver where possible, Debian/dpkg ordering for versions with `:` or `~`, string fallback otherwise)
+   - Parse source patterns and extract available versions using pattern matching (`@v` placeholder); parsed patterns are returned to callers so `installTransfer` reuses them without re-parsing. The candidate list is returned lexically sorted so that, with the stable `version.Sort`, selection stays deterministic even if two versions compare equal
+   - Select newest version via `version.Sort` (semver where possible, Debian/dpkg ordering for versions with `:`, `~`, or `+`, string fallback otherwise)
    - Skip if already installed (check target directory)
    - Download file, retrying the same transient request/body-read failures and HTTP 5xx/429 from scratch without range/resume requests. Each attempt uses a new temp file and invokes `OnDownloadProgress` again, so progress writers must be attempt-local. SHA256 is verified against the compressed bytes before decompression.
-   - Decompress if needed (xz, gz, zstd — detected from filename)
+   - Decompress if needed (xz, gz, zstd — detected from filename). The installed filename is derived from the target patterns via `buildTargetFilename`: the first pattern that produces a name without a compression suffix wins, and if every target pattern is a compressed variant the suffix is stripped, so the on-disk name always matches the decompressed content regardless of which source pattern matched
    - Atomically rename to final path; on cross-device rename failure, copy to a temp file on the destination filesystem, sync it, chmod it, then rename
    - Update `CurrentSymlink` in the target directory with an atomic temp-symlink rename
    - Create or replace `/var/lib/extensions/<CurrentSymlink>` pointing to the resolved target image path; this is a hard error because `systemd-sysext refresh` cannot see the staged image without it

--- a/yeti/config-reference.md
+++ b/yeti/config-reference.md
@@ -111,6 +111,8 @@ Mode=0644
 
 `MatchPattern` accepts space-separated patterns on a single line. The first is the primary pattern kept in `MatchPattern` for backward-compatible callers; the full ordered list is stored in `MatchPatterns`. During download, all valid source patterns are used to find matching files in the manifest.
 
+Downloads are always stored decompressed, so the installed filename is derived from the first target pattern that yields a name without a compression suffix; if every target pattern carries one (e.g. a target list mirroring the source list), the suffix is stripped. A target `MatchPattern` list like `component_@v.raw.zst component_@v.raw` therefore installs `component_<version>.raw` no matter which source variant matched.
+
 ```ini
 MatchPattern=component_@v.raw.xz component_@v.raw.gz component_@v.raw
 ```
@@ -166,7 +168,9 @@ Specifier values are cached for a single `LoadTransfers` call. `/etc/os-release`
 
 ## Version Comparison
 
-Versions extracted via `@v` are sorted descending (newest first) when selecting which version to install. `version.Compare` uses a dpkg-compatible comparator for Debian-style versions containing `:` or `~` so epochs and tilde pre-release ordering work correctly. Other versions are compared with `hashicorp/go-version` after stripping a leading `v`/`V`; if parsing fails, plain string comparison is used as fallback.
+Versions extracted via `@v` are sorted descending (newest first) when selecting which version to install. `version.Compare` uses a dpkg-compatible comparator for Debian-style versions containing `:`, `~`, or `+` so epochs and tilde pre-release ordering work correctly. `+` is included because semver treats everything after it as ignorable build metadata, which collapsed dpkg-derived sysext versions like `1+7.2-debian13-202607011055` (epoch encoded as `+` because `:` is not filename-safe) to equal precedence and made selection random. Other versions are compared with `hashicorp/go-version` after stripping a leading `v`/`V`; if parsing fails, plain string comparison is used as fallback.
+
+Version candidates extracted from the manifest are deduplicated in a set and returned lexically sorted before `version.Sort` runs. Because `version.Sort` is stable, this keeps selection reproducible even if a comparator gap ever makes two distinct versions compare equal.
 
 ## Retention and Active Versions
 

--- a/yeti/sdk-api.md
+++ b/yeti/sdk-api.md
@@ -184,13 +184,14 @@ type CheckResult struct {
 - `Download(ctx context.Context, httpClient *http.Client, url, targetPath, expectedHash string, mode uint32, onProgress ProgressFunc, opts ...Option) error` — Download with hash verification (on compressed bytes) and auto-decompression. Uses atomic rename; on cross-device rename failure, copies through a temp file on the destination device, syncs it, chmods it, then renames into place. If `httpClient` is nil, a default client with a 10-minute timeout is used. Default mode: `0644` if `mode == 0`. GETs and response-body reads retry transient network failures and HTTP 5xx/429 up to 3 total attempts with exponential backoff; each retry re-requests the file from scratch and uses a fresh temp file. 4xx other than 429 and checksum mismatches fail immediately. `WithRetryConfig(maxAttempts int, baseDelay time.Duration)` overrides retry bounds for tests or SDK consumers; `WithRetryNotify(func(attempt, maxAttempts int, reason error))` reports retry attempts
 - `ProgressFunc` — `func(contentLength int64) io.Writer` callback type for download progress. It may be called once per retry attempt, and should return a fresh independent writer each time to avoid double-counting
 - `DecompressReader(r io.Reader, compressionType string) (io.ReadCloser, error)` — Returns a decompressing reader for `"xz"`, `"gz"`, `"zstd"`, or passthrough for `""`
+- `StripCompressionSuffix(filename string) string` — Removes a trailing `.xz`/`.gz`/`.zst`/`.zstd` suffix (case-insensitive, longest suffix first). `Download` always stores files decompressed, so installed filenames are derived with this to keep the name consistent with the content
 
 ### `version`
 
 - `ParsePattern(pattern string) (*Pattern, error)` — Parse `@v`-style patterns. Returns `ErrEmptyPattern` or `ErrMissingVersionPlaceholder` on invalid input
 - `ParsePatterns(patternStrs []string) ([]*Pattern, error)` — Parse multiple patterns; returns all successfully parsed patterns and the first error encountered (callers proceed if at least one pattern parsed)
 - `ExtractVersionParsed(filename string, patterns []*Pattern) (version, matchedPattern string, ok bool)` — Try pre-parsed patterns against a filename (preferred for loops)
-- `Compare(v1, v2 string) int` — Version comparison (-1, 0, 1); uses dpkg-compatible ordering for Debian-style versions containing `:` or `~`, otherwise normalizes `v`/`V` prefixes and uses semantic comparison with string fallback
+- `Compare(v1, v2 string) int` — Version comparison (-1, 0, 1); uses dpkg-compatible ordering for Debian-style versions containing `:`, `~`, or `+` (semver would ignore everything after `+` as build metadata, collapsing dpkg-derived versions to equal), otherwise normalizes `v`/`V` prefixes and uses semantic comparison with string fallback
 - `Sort(versions []string)` — Sort descending (newest first)
 
 **`Pattern` methods:**


### PR DESCRIPTION
Fixes #127 — both the root cause and the minor observation.

## Root cause fixes

**1. `version.Compare` collapsed `+`-encoded Debian versions to equal.**

`isDebianVersion` now also treats `+` as a Debian marker, routing versions like `1+7.2-debian13-202607011055` through the dpkg-compatible comparator. Previously they took the hashicorp go-version path, which ignores everything after `+` as build metadata, so all snosi sysext versions compared equal:

```go
version.Compare("1+7.2-debian13-202607011055", "1+7.2-debian13-202607011341") // was 0, now -1
```

Frostyard sysext versions are always dpkg-derived (the `+` epoch encoding comes from snosi's postoutput because `:` is not filename-safe), so dpkg ordering is the correct semantic here. Epochs still dominate: `2+6.0-…` sorts above `1+7.2-…`.

**2. Map iteration made the tie-break random.**

`getAvailableVersions` now returns the candidate list lexically sorted (`slices.Sorted(maps.Keys(...))`) instead of in map iteration order. Since `version.Sort` is stable, any future comparator gap will now resolve reproducibly instead of installing a coin-flip version per run.

## Minor issue fix

The installed filename was always built from the **first** target `MatchPattern`, so a target list mirroring the source list (`incus_@v….raw.zst incus_@v….raw`) stored an uncompressed raw DDI under a `.raw.zst` name. `installTransfer` now derives the name via a new `buildTargetFilename` helper: it prefers the first target pattern whose name carries no compression suffix, and strips the suffix if every pattern is a compressed variant. Since `download.Download` always stores files decompressed, the on-disk name now always matches the content, regardless of which source pattern matched.

Adds `download.StripCompressionSuffix` as a public helper.

## Testing

All tests were written first and observed to fail with exactly the symptoms from the issue (Compare returning 0, random candidate order, file stored as `.raw.zst`):

- `version`: Compare/Sort cases for `+`-encoded versions, including determinism across both input orders and epoch dominance
- `updex`: `TestGetAvailableVersions_DeterministicOrder` (20 runs against a cached manifest), plus end-to-end `UpdateFeatures` tests for both an uncompressed source matched by the second pattern and a zstd-compressed source stored decompressed
- `download`: `TestStripCompressionSuffix` covering all suffixes and case-insensitivity

`make check` (fmt + lint + full test suite) passes; docs in `yeti/` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)