### PR TITLE
feat: discover systemd-sysupdate components

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version: "1.26.5"
       # More assembly might be required: Docker logins, GPG, etc.
       # It all depends on your needs.
       - name: Run GoReleaser

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version: "1.26.5"
 
       - name: Run GoReleaser Snapshot
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
 
       - name: Download dependencies
         run: go mod download
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
 
       - name: Download dependencies
         run: go mod download
@@ -96,7 +96,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
 
       - name: Verify go.mod is tidy
         run: |
@@ -127,12 +127,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.5"
 
       - name: Build binary
         run: |
           GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} make build
           ls -lh build/
-
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,9 +23,9 @@ updex is a Go SDK and CLI for managing systemd-sysext images. It replicates `sys
 **SDK-first design**: All logic lives in the `updex/` package as a public Go API. CLI commands in `cmd/` are thin Cobra wrappers that parse flags, call SDK functions, and format output. SDK code must never import CLI packages.
 
 Key packages:
-- `updex/` — Public SDK: `Client` struct with `Features()`, `EnableFeature()`, `DisableFeature()`, `UpdateFeatures()`, `CheckFeatures()`
+- `updex/` — Public SDK: `Client` struct with `Features()`, `EnableFeature()`, `DisableFeature()`, `UpdateFeatures()`, `CheckFeatures()`, `Components()`
 - `cmd/updex/` — Cobra command handlers calling SDK methods (flags, output formatting, progress bars)
-- `config/` — Parses `.transfer` and `.feature` INI files from systemd-style search paths
+- `config/` — Parses `.transfer` and `.feature` INI files from systemd-style search paths, including systemd-sysupdate "component" discovery (see below)
 - `download/` — HTTP downloads with bounded retry for transient failures, SHA256 verification, and decompression (xz, gz, zstd)
 - `manifest/` — Fetches/parses SHA256SUMS manifests with bounded retry for transient failures and optional GPG verification
 - `version/` — Pattern matching (`@v` placeholder) and semantic version comparison
@@ -34,13 +34,61 @@ Key packages:
 
 Entry point: `cmd/updex-cli/main.go` → `cmd/updex/root.go`
 
+### Component Discovery (`config/component.go`)
+
+systemd-sysupdate "components" (sysupdate.d(5) "Components") are named
+groupings of `.transfer`/`.feature` files under a `sysupdate.<name>.d/`
+directory, searched across `config.SearchRoots` (`/etc`, `/run`,
+`/usr/local/lib`, `/usr/lib`, in priority order — a package var, overridable
+in tests like `sysext.SysextDir`) — same precedence as the legacy default
+`sysupdate.d/` directory (`ComponentSearchPaths("")`). This exists so a
+sysext's transfer/feature files can move out of the shared default directory
+into their own versioning scope (native images now put OS A/B partition and
+UKI transfers in the default directory, which must not intersect with
+package-versioned sysext transfers) without updex losing track of them.
+
+- `DiscoverComponents()` scans `SearchRoots` for `sysupdate.<name>.d`
+  directories (`[a-zA-Z0-9_-]+` names only; dotted/empty names ignored) and
+  returns them sorted by name. It does not include the legacy default
+  component.
+- `LoadComponentFeatures(name)` / `LoadComponentTransfers(name)` load a
+  single named component (pass `""` for the legacy default).
+- `LoadAllFeatures(customPath)` / `LoadAllTransfers(customPath)` load the
+  domain updex operates on by default: the union of the legacy default
+  directory and every discovered component. A name collision (same feature
+  or transfer name from more than one source) resolves to the most specific
+  source — a named component beats the legacy default directory — and is
+  reported as a warning string rather than an error. `customPath` (mirrors
+  the `-C`/`--definitions` flag) bypasses discovery entirely, matching plain
+  `LoadFeatures`/`LoadTransfers(customPath)` behavior.
+- `IsSysextTransfer(t)` / `FilterSysextTransfers(transfers)` keep only
+  url-file-source, regular-file-target transfers, silently dropping the
+  non-sysext transfer shapes native images ship in the legacy default
+  directory: `Target Type=partition` (A/B root) and a `regular-file` target
+  with `PathRelativeTo` set (the UKI, relative to the ESP). `LoadAllTransfers`
+  always applies this filter; plain `LoadTransfers`/`LoadComponentTransfers`
+  do not (callers that want the filter must apply it themselves).
+- `ComponentOfPath(path)` recovers the component name (or `false` for the
+  legacy default / a `-C` override directory) from a loaded `Feature`'s
+  `FilePath`, used by `updex.Client.writeFeatureDropIn` to decide whether an
+  enable/disable drop-in goes under `/etc/sysupdate.<name>.d/` (via
+  `EtcComponentDir(name)`) or the legacy `/etc/sysupdate.d/`.
+- `updex.Client.loadDomain(component string)` is the single entry point
+  SDK methods use to resolve their read domain: `Definitions` set → that one
+  directory (component must be empty, else error); `component` set → just
+  that component; otherwise → the full union, with collision warnings routed
+  through the client's reporter. All `*FeatureOptions`/`*FeaturesOptions`
+  structs carry a `Component string` field for this; extend the options
+  struct for new component-scoped operations, never add package-level flag
+  state to the SDK.
+
 ## Code Patterns
 
 - Error messages: lowercase, no trailing punctuation, wrap with `fmt.Errorf("context: %w", err)`
 - SDK functions accept a `context.Context` and an options struct, return result structs + error
 - CLI output: `common.OutputJSON()` for `--json` flag, text tables otherwise
 - Tests use `t.TempDir()` for filesystem operations and mock runners for systemd commands
-- Configuration uses INI format with systemd-style priority paths: `/etc/sysupdate.d/`, `/run/sysupdate.d/`, `/usr/local/lib/sysupdate.d/`, `/usr/lib/sysupdate.d/`
+- Configuration uses INI format with systemd-style priority paths: `/etc/sysupdate.d/`, `/run/sysupdate.d/`, `/usr/local/lib/sysupdate.d/`, `/usr/lib/sysupdate.d/` (plus the same four roots per discovered component, see above)
 - Transfer targets default to staging in `/var/lib/extensions.d`; `CurrentSymlink` is optional legacy state and must not be required for `/var/lib/extensions` sysext links
 
 ## Go Version

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Designed for systems like Debian Trixie that don't ship with `systemd-sysupdate`
 ## Features
 
 - Feature-based management of sysext images (enable/disable groups of transfers)
+- systemd-sysupdate "component" discovery (`sysupdate.<name>.d/`, see sysupdate.d(5) "Components"), with the legacy default `sysupdate.d/` directory folded into the same domain
 - Download sysext images from remote HTTP sources
 - SHA256 hash verification via `SHA256SUMS` manifests
 - Bounded retry with exponential backoff for transient network failures and HTTP 5xx/429 responses
@@ -57,13 +58,23 @@ func main() {
 
     ctx := context.Background()
 
-    // List all features
-    features, err := client.Features(ctx)
+    // List all features (union of the legacy default directory and every
+    // discovered systemd-sysupdate component)
+    features, err := client.Features(ctx, updex.FeaturesOptions{})
     if err != nil {
         log.Fatal(err)
     }
     for _, f := range features {
         fmt.Printf("%s: enabled=%v (%s)\n", f.Name, f.Enabled, f.Description)
+    }
+
+    // List discovered components
+    components, err := client.Components(ctx)
+    if err != nil {
+        log.Fatal(err)
+    }
+    for _, c := range components {
+        fmt.Printf("%s: %s (%d features)\n", c.Name, c.SourceDir, c.FeatureCount)
     }
 
     // Enable a feature and download extensions immediately
@@ -114,11 +125,14 @@ func main() {
 
 | Method | Signature | Description |
 | --- | --- | --- |
-| `Features` | `Features(ctx) ([]FeatureInfo, error)` | List all features with status and associated transfers |
+| `Features` | `Features(ctx, FeaturesOptions) ([]FeatureInfo, error)` | List all features with status and associated transfers |
 | `EnableFeature` | `EnableFeature(ctx, name, EnableFeatureOptions) (*FeatureActionResult, error)` | Enable a feature via drop-in config |
 | `DisableFeature` | `DisableFeature(ctx, name, DisableFeatureOptions) (*FeatureActionResult, error)` | Disable a feature via drop-in config |
 | `UpdateFeatures` | `UpdateFeatures(ctx, UpdateFeaturesOptions) ([]UpdateFeaturesResult, error)` | Download and install newest versions for all enabled features |
 | `CheckFeatures` | `CheckFeatures(ctx, CheckFeaturesOptions) ([]CheckFeaturesResult, error)` | Check if newer versions are available |
+| `Components` | `Components(ctx) ([]ComponentInfo, error)` | List discovered systemd-sysupdate components (name, source directory, feature count) |
+
+`FeaturesOptions`, `EnableFeatureOptions`, `DisableFeatureOptions`, `UpdateFeaturesOptions`, and `CheckFeaturesOptions` all carry a `Component string` field that scopes the operation to a single named systemd-sysupdate component instead of the default union domain (see "systemd-sysupdate Components" below). It cannot be combined with a `Definitions` override on `ClientConfig`.
 
 ### ClientConfig
 
@@ -139,26 +153,35 @@ Manifest fetches and file downloads retry transient request/body-read failures a
 ### Option Structs
 
 ```go
+type FeaturesOptions struct {
+    Component string // Scope to a single named component (default: union of all)
+}
+
 type EnableFeatureOptions struct {
-    Now       bool // Immediately download extensions after enabling
-    DryRun    bool // Preview changes without modifying filesystem
-    NoRefresh bool // Skip systemd-sysext refresh after download
+    Now       bool   // Immediately download extensions after enabling
+    DryRun    bool   // Preview changes without modifying filesystem
+    NoRefresh bool   // Skip systemd-sysext refresh after download
+    Component string // Scope to a single named component (default: union of all)
 }
 
 type DisableFeatureOptions struct {
-    Now       bool // Immediately unmerge and remove extension files
-    Force     bool // Allow removal of merged extensions (requires reboot)
-    DryRun    bool // Preview changes without modifying filesystem
-    NoRefresh bool // Skip systemd-sysext refresh
+    Now       bool   // Immediately unmerge and remove extension files
+    Force     bool   // Allow removal of merged extensions (requires reboot)
+    DryRun    bool   // Preview changes without modifying filesystem
+    NoRefresh bool   // Skip systemd-sysext refresh
+    Component string // Scope to a single named component (default: union of all)
 }
 
 type UpdateFeaturesOptions struct {
-    DryRun    bool // Preview changes without modifying filesystem or sysext state
-    NoRefresh bool // Skip systemd-sysext refresh after update
-    NoVacuum  bool // Skip removing old versions after update
+    DryRun    bool   // Preview changes without modifying filesystem or sysext state
+    NoRefresh bool   // Skip systemd-sysext refresh after update
+    NoVacuum  bool   // Skip removing old versions after update
+    Component string // Scope to a single named component (default: union of all)
 }
 
-type CheckFeaturesOptions struct{}
+type CheckFeaturesOptions struct {
+    Component string // Scope to a single named component (default: union of all)
+}
 ```
 
 ## CLI Usage
@@ -194,6 +217,13 @@ sudo updex --dry-run features update
 # Check for available updates (read-only)
 updex features check
 
+# Scope any of the above to a single named component
+updex features list --component=docker
+sudo updex features update --component=docker
+
+# List discovered systemd-sysupdate components
+updex components
+
 # Enable automatic daily updates
 sudo updex daemon enable
 
@@ -215,16 +245,30 @@ sudo updex daemon disable
 | `--dry-run` | Preview changes without modifying filesystem |
 | `--verbose` | Enable verbose output |
 
+### `features` Flags
+
+| Flag | Description |
+| --- | --- |
+| `--component` | Scope the operation to a single named systemd-sysupdate component instead of the default union of the legacy default directory and every discovered component. Cannot be combined with `-C, --definitions`. |
+
 ## Configuration
 
-updex reads `.transfer` and `.feature` files from these directories (in priority order):
+By default updex reads `.transfer` and `.feature` files from the union of two kinds of sources:
+
+**The legacy default directories** (in priority order):
 
 1. `/etc/sysupdate.d/` (highest priority)
 2. `/run/sysupdate.d/`
 3. `/usr/local/lib/sysupdate.d/`
 4. `/usr/lib/sysupdate.d/`
 
-Only the first occurrence of a given filename is used. The `-C` flag overrides all search paths with a custom directory.
+**Every discovered systemd-sysupdate component** — a named grouping of `.transfer`/`.feature` files under a `sysupdate.<name>.d/` directory (see sysupdate.d(5) "Components"), searched across the same four roots with the same priority order, e.g. `/etc/sysupdate.docker.d/` overrides `/usr/lib/sysupdate.docker.d/`. Run `updex components` to see what's discovered.
+
+Within each source, only the first occurrence of a given filename is used. Feature and transfer names are expected to be globally unique across the whole union (they're derived from distinct sysext names); if a name is defined in more than one source, the most specific source wins — a named component beats the legacy default directory — and the collision is logged as a warning.
+
+Non-sysext transfers that may share the legacy default directory on native OS images (GPT `partition` targets for an A/B root, or the UKI's `regular-file` target relative to the ESP) are silently skipped rather than erroring.
+
+The `-C, --definitions` flag overrides all of the above with a single explicit directory (no component discovery, no union) — the original, pre-component behavior. It cannot be combined with `--component`. The `--component=<name>` flag instead scopes the read/write domain to one named component's own search paths.
 
 ### Example Transfer File
 
@@ -361,6 +405,39 @@ To completely hide a feature, create a symlink to `/dev/null`:
 ```bash
 ln -s /dev/null /etc/sysupdate.d/devel.feature
 ```
+
+## systemd-sysupdate Components
+
+A component is a named grouping of `.transfer`/`.feature` files, used to give a
+sysext its own versioning scope separate from the shared default directory
+(see sysupdate.d(5) "Components"). Move a sysext's files out of
+`/usr/lib/sysupdate.d/` into `/usr/lib/sysupdate.<name>.d/` and updex picks
+them up automatically as component `<name>`, with the same
+`/etc` > `/run` > `/usr/local/lib` > `/usr/lib` override precedence used for
+the legacy default directory:
+
+```
+/usr/lib/sysupdate.docker.d/docker.transfer
+/usr/lib/sysupdate.docker.d/docker.feature
+```
+
+List what's discovered:
+
+```bash
+updex components
+# COMPONENT  SOURCE                          FEATURES
+# docker     /usr/lib/sysupdate.docker.d     1
+# incus      /usr/lib/sysupdate.incus.d      1
+```
+
+`updex features list` (and every other `features` subcommand) reads the union
+of the legacy default directory and every discovered component by default;
+pass `--component=<name>` to scope to just one. Enabling or disabling a
+feature writes its drop-in under the matching scope — a component-scoped
+feature gets `/etc/sysupdate.<name>.d/<feature>.feature.d/00-updex.conf`, a
+legacy default (or `-C`/`--definitions`-loaded) feature keeps
+`/etc/sysupdate.d/<feature>.feature.d/00-updex.conf` — so reads and writes
+always agree on where a feature's overrides live.
 
 ## Remote Manifest Format
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ func main() {
 
 | Method | Signature | Description |
 | --- | --- | --- |
-| `Features` | `Features(ctx, FeaturesOptions) ([]FeatureInfo, error)` | List all features with status and associated transfers |
+| `Features` | `Features(ctx, opts ...FeaturesOptions) ([]FeatureInfo, error)` | List all features with status and associated transfers |
 | `EnableFeature` | `EnableFeature(ctx, name, EnableFeatureOptions) (*FeatureActionResult, error)` | Enable a feature via drop-in config |
 | `DisableFeature` | `DisableFeature(ctx, name, DisableFeatureOptions) (*FeatureActionResult, error)` | Disable a feature via drop-in config |
 | `UpdateFeatures` | `UpdateFeatures(ctx, UpdateFeaturesOptions) ([]UpdateFeaturesResult, error)` | Download and install newest versions for all enabled features |

--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ func main() {
     ctx := context.Background()
 
     // List all features (union of the legacy default directory and every
-    // discovered systemd-sysupdate component)
-    features, err := client.Features(ctx, updex.FeaturesOptions{})
+    // discovered systemd-sysupdate component). opts is variadic: omit it
+    // for the default domain, or pass updex.FeaturesOptions{Component: "docker"}
+    // to scope to one component.
+    features, err := client.Features(ctx)
     if err != nil {
         log.Fatal(err)
     }

--- a/cmd/updex/components.go
+++ b/cmd/updex/components.go
@@ -1,0 +1,65 @@
+package updex
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/frostyard/clix"
+	"github.com/spf13/cobra"
+)
+
+func newComponentsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "components",
+		Short: "List discovered systemd-sysupdate components",
+		Long: `List the systemd-sysupdate components discovered on the system.
+
+A component is a named grouping of .transfer/.feature files under a
+sysupdate.<name>.d directory (see sysupdate.d(5) "Components"), searched
+across /etc, /run, /usr/local/lib, and /usr/lib in that priority order. This
+does not list the legacy default sysupdate.d directory itself; use
+'updex features list' (which reads the union of the default directory and
+every component below) to see everything.
+
+OUTPUT COLUMNS:
+  COMPONENT  - Component name
+  SOURCE     - Highest-priority directory providing this component
+  FEATURES   - Number of .feature files defined by this component`,
+		Example: `  # List discovered components
+  updex components
+
+  # List in JSON format
+  updex components --json`,
+		Args: cobra.NoArgs,
+		RunE: runComponents,
+	}
+}
+
+func runComponents(cmd *cobra.Command, args []string) error {
+	client := newClient()
+
+	components, err := client.Components(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	if clix.JSONOutput {
+		_, err = clix.OutputJSON(components)
+		return err
+	}
+
+	if len(components) == 0 {
+		fmt.Println("No components discovered.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "COMPONENT\tSOURCE\tFEATURES")
+	for _, c := range components {
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%d\n", c.Name, c.SourceDir, c.FeatureCount)
+	}
+	_ = w.Flush()
+
+	return nil
+}

--- a/cmd/updex/features.go
+++ b/cmd/updex/features.go
@@ -9,6 +9,7 @@ var (
 	featureDisableForce bool
 	featureEnableNow    bool
 	featureUpdateNoVac  bool
+	featureComponent    string
 )
 
 func newFeaturesCmd() *cobra.Command {
@@ -28,6 +29,11 @@ CONFIGURATION FILES:
   - /usr/local/lib/sysupdate.d/*.feature
   - /usr/lib/sysupdate.d/*.feature
 
+By default, features and transfers are read from the union of the legacy
+default directories above and every discovered systemd-sysupdate component
+(sysupdate.<name>.d/*, see 'updex components'). Use --component=<name> to
+scope an operation to a single named component instead.
+
 SUBCOMMANDS:
   list     Show all features and their status
   enable   Enable a feature (optionally download immediately)
@@ -46,9 +52,11 @@ SUBCOMMANDS:
   # Update all enabled features
   sudo updex features update
 
-  # Check for available updates
-  updex features check`,
+  # Scope an operation to a single component
+  updex features list --component=docker`,
 	}
+
+	cmd.PersistentFlags().StringVar(&featureComponent, "component", "", "Scope the operation to a single named systemd-sysupdate component")
 
 	cmd.AddCommand(newFeaturesListCmd())
 	cmd.AddCommand(newFeaturesEnableCmd())

--- a/cmd/updex/features_run.go
+++ b/cmd/updex/features_run.go
@@ -14,7 +14,9 @@ import (
 func runFeaturesList(cmd *cobra.Command, args []string) error {
 	client := newClient()
 
-	features, err := client.Features(cmd.Context())
+	features, err := client.Features(cmd.Context(), updex.FeaturesOptions{
+		Component: featureComponent,
+	})
 	if err != nil {
 		return err
 	}
@@ -68,6 +70,7 @@ func runFeaturesEnable(cmd *cobra.Command, args []string) error {
 		Now:       featureEnableNow,
 		DryRun:    clix.DryRun,
 		NoRefresh: noRefresh,
+		Component: featureComponent,
 	}
 
 	result, err := client.EnableFeature(cmd.Context(), args[0], opts)
@@ -109,6 +112,7 @@ func runFeaturesDisable(cmd *cobra.Command, args []string) error {
 		Force:     featureDisableForce,
 		DryRun:    clix.DryRun,
 		NoRefresh: noRefresh,
+		Component: featureComponent,
 	}
 
 	result, err := client.DisableFeature(cmd.Context(), args[0], opts)
@@ -155,6 +159,7 @@ func runFeaturesUpdate(cmd *cobra.Command, args []string) error {
 		DryRun:    clix.DryRun,
 		NoRefresh: noRefresh,
 		NoVacuum:  featureUpdateNoVac,
+		Component: featureComponent,
 	}
 
 	results, err := client.UpdateFeatures(cmd.Context(), opts)
@@ -198,7 +203,9 @@ func runFeaturesUpdate(cmd *cobra.Command, args []string) error {
 func runFeaturesCheck(cmd *cobra.Command, args []string) error {
 	client := newClient()
 
-	results, err := client.CheckFeatures(cmd.Context(), updex.CheckFeaturesOptions{})
+	results, err := client.CheckFeatures(cmd.Context(), updex.CheckFeaturesOptions{
+		Component: featureComponent,
+	})
 
 	if clix.JSONOutput {
 		_, jsonErr := clix.OutputJSON(results)

--- a/cmd/updex/root.go
+++ b/cmd/updex/root.go
@@ -37,16 +37,22 @@ func NewRootCmd() *cobra.Command {
 Features group related sysext transfers that can be enabled, disabled,
 updated, and checked together. Use 'updex features' to manage them.
 
-Configuration is read from .feature and .transfer files in:
+Configuration is read from .feature and .transfer files in the legacy
+default directories:
   - /etc/sysupdate.d/
   - /run/sysupdate.d/
   - /usr/local/lib/sysupdate.d/
-  - /usr/lib/sysupdate.d/`,
+  - /usr/lib/sysupdate.d/
+
+...and from every discovered systemd-sysupdate component directory
+(sysupdate.<name>.d/, see 'updex components' and sysupdate.d(5)
+"Components"), searched across the same four roots.`,
 	}
 
 	registerAppFlags(cmd)
 	cmd.AddCommand(newFeaturesCmd())
 	cmd.AddCommand(newDaemonCmd())
+	cmd.AddCommand(newComponentsCmd())
 
 	return cmd
 }

--- a/config/component.go
+++ b/config/component.go
@@ -1,0 +1,157 @@
+package config
+
+import (
+	"cmp"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+// SearchRoots are the systemd-style root directories scanned for the legacy
+// default component (SearchRoots[i]+"/sysupdate.d") and for named components
+// (SearchRoots[i]+"/sysupdate.<name>.d"), in priority order (earlier roots
+// win). Overridable in tests.
+var SearchRoots = []string{
+	"/etc",
+	"/run",
+	"/usr/local/lib",
+	"/usr/lib",
+}
+
+// componentDirName returns the sysupdate.d subdirectory name for a
+// component: "sysupdate.d" for the legacy default (empty name), or
+// "sysupdate.<name>.d" for a named component (see sysupdate.d(5)
+// "Components").
+func componentDirName(name string) string {
+	if name == "" {
+		return "sysupdate.d"
+	}
+	return "sysupdate." + name + ".d"
+}
+
+// ComponentSearchPaths returns the systemd-style search-path directories for
+// a component, in priority order (earlier entries win). Pass "" for the
+// legacy default component (/etc/sysupdate.d, /run/sysupdate.d, ...).
+func ComponentSearchPaths(name string) []string {
+	dirName := componentDirName(name)
+	paths := make([]string, len(SearchRoots))
+	for i, root := range SearchRoots {
+		paths[i] = filepath.Join(root, dirName)
+	}
+	return paths
+}
+
+// defaultSearchPaths are the search paths for the legacy default component.
+func defaultSearchPaths() []string {
+	return ComponentSearchPaths("")
+}
+
+// EtcComponentDir returns the /etc override directory for a component's
+// definitions (e.g. "/etc/sysupdate.docker.d"), used when writing drop-in
+// configuration overrides. Pass "" for the legacy default component
+// (/etc/sysupdate.d).
+func EtcComponentDir(name string) string {
+	return filepath.Join("/etc", componentDirName(name))
+}
+
+// componentNamePattern matches systemd-sysupdate component names (see
+// sysupdate.d(5)): non-empty strings drawn from [a-zA-Z0-9_-]+. Dotted or
+// empty names are rejected.
+var componentNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// parseComponentDirName returns the component name encoded in a
+// "sysupdate.<name>.d" directory name, or ("", false) if dirName doesn't
+// have that shape, encodes an invalid/empty name, or is the legacy default
+// "sysupdate.d" directory itself.
+func parseComponentDirName(dirName string) (string, bool) {
+	const prefix, suffix = "sysupdate.", ".d"
+	if len(dirName) < len(prefix)+len(suffix) ||
+		!strings.HasPrefix(dirName, prefix) || !strings.HasSuffix(dirName, suffix) {
+		return "", false
+	}
+	name := dirName[len(prefix) : len(dirName)-len(suffix)]
+	if name == "" || !componentNamePattern.MatchString(name) {
+		return "", false
+	}
+	return name, true
+}
+
+// ComponentOfPath returns the component name encoded in path's parent
+// directory (a sysupdate.<name>.d directory), or ("", false) if the parent
+// is the legacy default sysupdate.d directory, or doesn't match the
+// component shape at all (e.g. a --definitions override directory).
+func ComponentOfPath(path string) (string, bool) {
+	return parseComponentDirName(filepath.Base(filepath.Dir(path)))
+}
+
+// Component describes a discovered systemd-sysupdate component: a named
+// grouping of .transfer/.feature files under sysupdate.<name>.d directories
+// (see sysupdate.d(5) "Components"). Components let a sysext's transfer and
+// feature files move out of the shared default sysupdate.d directory into
+// their own versioning scope without updex losing track of them.
+type Component struct {
+	// Name is the component name, e.g. "docker" for sysupdate.docker.d.
+	Name string
+	// SearchPaths lists the component's search-path directories that
+	// actually exist on disk, in priority order (highest priority first).
+	SearchPaths []string
+}
+
+// DiscoverComponents scans SearchRoots for sysupdate.<name>.d directories
+// and returns the named components found, sorted by name. It does not
+// include the legacy default component (plain sysupdate.d); use
+// ComponentSearchPaths("") for that. Directory names that don't match the
+// component charset (see parseComponentDirName) are ignored.
+func DiscoverComponents() ([]Component, error) {
+	found := make(map[string]bool)
+
+	for _, root := range SearchRoots {
+		entries, err := os.ReadDir(root)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to read directory %s: %w", root, err)
+		}
+
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			name, ok := parseComponentDirName(entry.Name())
+			if !ok {
+				continue
+			}
+			found[name] = true
+		}
+	}
+
+	components := make([]Component, 0, len(found))
+	for name := range found {
+		components = append(components, Component{
+			Name:        name,
+			SearchPaths: existingDirs(ComponentSearchPaths(name)),
+		})
+	}
+
+	slices.SortFunc(components, func(a, b Component) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+
+	return components, nil
+}
+
+// existingDirs filters paths to those that exist as directories on disk,
+// preserving order.
+func existingDirs(paths []string) []string {
+	var result []string
+	for _, p := range paths {
+		if info, err := os.Stat(p); err == nil && info.IsDir() {
+			result = append(result, p)
+		}
+	}
+	return result
+}

--- a/config/component_test.go
+++ b/config/component_test.go
@@ -1,0 +1,580 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// withTestSearchRoots points SearchRoots at four fresh temp directories
+// (mimicking /etc, /run, /usr/local/lib, /usr/lib) for the duration of the
+// test, restoring the original value on cleanup. Returns the roots in
+// priority order.
+func withTestSearchRoots(t *testing.T) []string {
+	t.Helper()
+	root := t.TempDir()
+	roots := []string{
+		filepath.Join(root, "etc"),
+		filepath.Join(root, "run"),
+		filepath.Join(root, "usr", "local", "lib"),
+		filepath.Join(root, "usr", "lib"),
+	}
+	for _, d := range roots {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatalf("failed to create root %s: %v", d, err)
+		}
+	}
+
+	original := SearchRoots
+	SearchRoots = roots
+	t.Cleanup(func() { SearchRoots = original })
+
+	return roots
+}
+
+// writeFeatureFixture writes a minimal .feature file under dir.
+func writeFeatureFixture(t *testing.T, dir, name string, enabled bool) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("failed to create dir %s: %v", dir, err)
+	}
+	content := "[Feature]\nEnabled=" + map[bool]string{true: "true", false: "false"}[enabled] + "\n"
+	path := filepath.Join(dir, name+".feature")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+}
+
+// writeSysextTransferFixture writes a minimal sysext-shaped .transfer file
+// (url-file source, regular-file target) under dir, tagged with sourceTag so
+// tests can tell which copy of a colliding name won a merge.
+func writeSysextTransferFixture(t *testing.T, dir, name, sourceTag string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("failed to create dir %s: %v", dir, err)
+	}
+	content := `[Transfer]
+Features=` + name + `
+
+[Source]
+Type=url-file
+Path=https://example.com/` + sourceTag + `/` + name + `
+MatchPattern=` + name + `_@v.raw
+
+[Target]
+Type=regular-file
+Path=/var/lib/extensions.d
+MatchPattern=` + name + `_@v.raw
+CurrentSymlink=` + name + `.raw
+`
+	path := filepath.Join(dir, name+".transfer")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+}
+
+// writePartitionTransferFixture writes an OS A/B partition transfer, the
+// shape native (non-sysext) images ship in the legacy default directory.
+func writePartitionTransferFixture(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("failed to create dir %s: %v", dir, err)
+	}
+	content := `[Transfer]
+Verify=yes
+
+[Source]
+Type=url-file
+Path=https://example.com/os
+MatchPattern=cayo_@v.root.raw.xz
+
+[Target]
+Type=partition
+Path=auto
+MatchPattern=cayo_@v_r
+`
+	path := filepath.Join(dir, name+".transfer")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+}
+
+// writeUKITransferFixture writes the UKI regular-file transfer under
+// /EFI/Linux (PathRelativeTo=boot), the other non-sysext shape found in the
+// legacy default directory on native images.
+func writeUKITransferFixture(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("failed to create dir %s: %v", dir, err)
+	}
+	content := `[Transfer]
+Verify=yes
+
+[Source]
+Type=url-file
+Path=https://example.com/os
+MatchPattern=cayo_@v.efi
+
+[Target]
+Type=regular-file
+Path=/EFI/Linux
+PathRelativeTo=boot
+MatchPattern=cayo_@v.efi
+`
+	path := filepath.Join(dir, name+".transfer")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+}
+
+func TestComponentSearchPaths(t *testing.T) {
+	roots := withTestSearchRoots(t)
+
+	t.Run("default component", func(t *testing.T) {
+		got := ComponentSearchPaths("")
+		want := []string{
+			filepath.Join(roots[0], "sysupdate.d"),
+			filepath.Join(roots[1], "sysupdate.d"),
+			filepath.Join(roots[2], "sysupdate.d"),
+			filepath.Join(roots[3], "sysupdate.d"),
+		}
+		if !slices.Equal(got, want) {
+			t.Errorf("ComponentSearchPaths(\"\") = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("named component", func(t *testing.T) {
+		got := ComponentSearchPaths("docker")
+		want := []string{
+			filepath.Join(roots[0], "sysupdate.docker.d"),
+			filepath.Join(roots[1], "sysupdate.docker.d"),
+			filepath.Join(roots[2], "sysupdate.docker.d"),
+			filepath.Join(roots[3], "sysupdate.docker.d"),
+		}
+		if !slices.Equal(got, want) {
+			t.Errorf("ComponentSearchPaths(\"docker\") = %v, want %v", got, want)
+		}
+	})
+}
+
+func TestEtcComponentDir(t *testing.T) {
+	if got, want := EtcComponentDir(""), filepath.Join("/etc", "sysupdate.d"); got != want {
+		t.Errorf("EtcComponentDir(\"\") = %q, want %q", got, want)
+	}
+	if got, want := EtcComponentDir("docker"), filepath.Join("/etc", "sysupdate.docker.d"); got != want {
+		t.Errorf("EtcComponentDir(\"docker\") = %q, want %q", got, want)
+	}
+}
+
+func TestParseComponentDirName(t *testing.T) {
+	tests := []struct {
+		dirName  string
+		wantName string
+		wantOK   bool
+	}{
+		{"sysupdate.docker.d", "docker", true},
+		{"sysupdate.claude-desktop.d", "claude-desktop", true},
+		{"sysupdate.1password_cli.d", "1password_cli", true},
+		{"sysupdate.d", "", false},         // legacy default, not a named component
+		{"sysupdate..d", "", false},        // empty name
+		{"sysupdate.foo.bar.d", "", false}, // dotted name, invalid charset
+		{"sysupdate.foo!bar.d", "", false}, // invalid charset
+		{"notsysupdate.foo.d", "", false},  // wrong prefix
+		{"sysupdate.foo.dir", "", false},   // wrong suffix
+		{"sysupdate.foo", "", false},       // missing .d suffix
+		{"other-directory", "", false},     // unrelated directory
+		{"sysupdate.FOO_bar-1.d", "FOO_bar-1", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.dirName, func(t *testing.T) {
+			name, ok := parseComponentDirName(tc.dirName)
+			if ok != tc.wantOK || name != tc.wantName {
+				t.Errorf("parseComponentDirName(%q) = (%q, %v), want (%q, %v)",
+					tc.dirName, name, ok, tc.wantName, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestComponentOfPath(t *testing.T) {
+	tests := []struct {
+		path     string
+		wantName string
+		wantOK   bool
+	}{
+		{"/usr/lib/sysupdate.docker.d/docker.feature", "docker", true},
+		{"/etc/sysupdate.docker.d/docker.feature.d/00-updex.conf", "", false}, // parent is the drop-in dir, not the component dir
+		{"/usr/lib/sysupdate.d/docker.feature", "", false},                    // legacy default
+		{"/tmp/custom-dir/docker.feature", "", false},                         // --definitions override dir
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.path, func(t *testing.T) {
+			name, ok := ComponentOfPath(tc.path)
+			if ok != tc.wantOK || name != tc.wantName {
+				t.Errorf("ComponentOfPath(%q) = (%q, %v), want (%q, %v)",
+					tc.path, name, ok, tc.wantName, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestDiscoverComponents(t *testing.T) {
+	roots := withTestSearchRoots(t)
+	etc, _, usrLocalLib, usrLib := roots[0], roots[1], roots[2], roots[3]
+
+	// docker: only in /usr/lib (lowest precedence root actually present)
+	writeFeatureFixture(t, filepath.Join(usrLib, "sysupdate.docker.d"), "docker", true)
+	// incus: present in both /etc (override) and /usr/lib (base)
+	writeFeatureFixture(t, filepath.Join(etc, "sysupdate.incus.d"), "incus", false)
+	writeFeatureFixture(t, filepath.Join(usrLib, "sysupdate.incus.d"), "incus", true)
+	// nix: in /usr/local/lib only
+	writeFeatureFixture(t, filepath.Join(usrLocalLib, "sysupdate.nix.d"), "nix", true)
+
+	// Invalid entries that must be ignored.
+	if err := os.MkdirAll(filepath.Join(usrLib, "sysupdate.foo.bar.d"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(usrLib, "sysupdate.d"), 0755); err != nil {
+		t.Fatal(err) // legacy default, not a named component
+	}
+	if err := os.WriteFile(filepath.Join(usrLib, "sysupdate.notadir.d"), []byte("x"), 0644); err != nil {
+		t.Fatal(err) // a file, not a directory
+	}
+
+	components, err := DiscoverComponents()
+	if err != nil {
+		t.Fatalf("DiscoverComponents() error = %v", err)
+	}
+
+	if len(components) != 3 {
+		names := make([]string, len(components))
+		for i, c := range components {
+			names[i] = c.Name
+		}
+		t.Fatalf("expected 3 components, got %d: %v", len(components), names)
+	}
+
+	// Sorted by name.
+	wantNames := []string{"docker", "incus", "nix"}
+	for i, want := range wantNames {
+		if components[i].Name != want {
+			t.Errorf("components[%d].Name = %q, want %q", i, components[i].Name, want)
+		}
+	}
+
+	// docker: only usr/lib exists.
+	docker := components[0]
+	if len(docker.SearchPaths) != 1 || docker.SearchPaths[0] != filepath.Join(usrLib, "sysupdate.docker.d") {
+		t.Errorf("docker.SearchPaths = %v, want [%s]", docker.SearchPaths, filepath.Join(usrLib, "sysupdate.docker.d"))
+	}
+
+	// incus: etc (highest priority) then usr/lib, in that order.
+	incus := components[1]
+	wantIncus := []string{filepath.Join(etc, "sysupdate.incus.d"), filepath.Join(usrLib, "sysupdate.incus.d")}
+	if !slices.Equal(incus.SearchPaths, wantIncus) {
+		t.Errorf("incus.SearchPaths = %v, want %v", incus.SearchPaths, wantIncus)
+	}
+}
+
+func TestDiscoverComponents_NoRootsExist(t *testing.T) {
+	root := t.TempDir()
+	original := SearchRoots
+	SearchRoots = []string{filepath.Join(root, "does-not-exist")}
+	t.Cleanup(func() { SearchRoots = original })
+
+	components, err := DiscoverComponents()
+	if err != nil {
+		t.Fatalf("DiscoverComponents() error = %v", err)
+	}
+	if len(components) != 0 {
+		t.Errorf("expected no components, got %v", components)
+	}
+}
+
+func TestIsSysextTransfer(t *testing.T) {
+	tests := []struct {
+		name string
+		t    *Transfer
+		want bool
+	}{
+		{
+			name: "regular sysext transfer",
+			t:    &Transfer{Source: SourceSection{Type: "url-file"}, Target: TargetSection{Type: "regular-file"}},
+			want: true,
+		},
+		{
+			name: "implicit regular-file target (Type unset)",
+			t:    &Transfer{Source: SourceSection{Type: "url-file"}, Target: TargetSection{}},
+			want: true,
+		},
+		{
+			name: "partition target",
+			t:    &Transfer{Source: SourceSection{Type: "url-file"}, Target: TargetSection{Type: "partition"}},
+			want: false,
+		},
+		{
+			name: "regular-file target relative to boot (UKI)",
+			t:    &Transfer{Source: SourceSection{Type: "url-file"}, Target: TargetSection{Type: "regular-file", PathRelativeTo: "boot"}},
+			want: false,
+		},
+		{
+			name: "non-url-file source",
+			t:    &Transfer{Source: SourceSection{Type: "url-tar"}, Target: TargetSection{Type: "regular-file"}},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsSysextTransfer(tc.t); got != tc.want {
+				t.Errorf("IsSysextTransfer() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFilterSysextTransfers(t *testing.T) {
+	transfers := []*Transfer{
+		{Component: "docker", Source: SourceSection{Type: "url-file"}, Target: TargetSection{Type: "regular-file"}},
+		{Component: "10-root-verity", Source: SourceSection{Type: "url-file"}, Target: TargetSection{Type: "partition"}},
+		{Component: "90-uki", Source: SourceSection{Type: "url-file"}, Target: TargetSection{Type: "regular-file", PathRelativeTo: "boot"}},
+		{Component: "incus", Source: SourceSection{Type: "url-file"}, Target: TargetSection{Type: "regular-file"}},
+	}
+
+	filtered := FilterSysextTransfers(transfers)
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 sysext transfers, got %d", len(filtered))
+	}
+	if filtered[0].Component != "docker" || filtered[1].Component != "incus" {
+		t.Errorf("unexpected filtered transfers: %v, %v", filtered[0].Component, filtered[1].Component)
+	}
+}
+
+func TestLoadAllFeatures_UnionAcrossComponents(t *testing.T) {
+	roots := withTestSearchRoots(t)
+	etc, _, _, usrLib := roots[0], roots[1], roots[2], roots[3]
+
+	// Legacy default directory: "shared" feature not shadowed by any component.
+	writeFeatureFixture(t, filepath.Join(usrLib, "sysupdate.d"), "shared", true)
+
+	// A component with its own feature.
+	writeFeatureFixture(t, filepath.Join(usrLib, "sysupdate.incus.d"), "incus", false)
+
+	features, warnings, err := LoadAllFeatures("")
+	if err != nil {
+		t.Fatalf("LoadAllFeatures() error = %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("expected no collision warnings, got %v", warnings)
+	}
+	if len(features) != 2 {
+		names := make([]string, len(features))
+		for i, f := range features {
+			names[i] = f.Name
+		}
+		t.Fatalf("expected 2 features, got %d: %v", len(features), names)
+	}
+	if features[0].Name != "incus" || features[1].Name != "shared" {
+		t.Errorf("unexpected feature names: %q, %q", features[0].Name, features[1].Name)
+	}
+
+	// /etc override on the component wins over the component's own /usr/lib file.
+	writeFeatureFixture(t, filepath.Join(etc, "sysupdate.incus.d"), "incus", true)
+	features, _, err = LoadAllFeatures("")
+	if err != nil {
+		t.Fatalf("LoadAllFeatures() error = %v", err)
+	}
+	idx := slices.IndexFunc(features, func(f *Feature) bool { return f.Name == "incus" })
+	if idx < 0 {
+		t.Fatalf("incus feature missing")
+	}
+	if !features[idx].Enabled {
+		t.Errorf("expected /etc override (Enabled=true) to win, got Enabled=%v", features[idx].Enabled)
+	}
+}
+
+func TestLoadAllFeatures_ComponentWinsCollisionWithDefault(t *testing.T) {
+	roots := withTestSearchRoots(t)
+	_, _, _, usrLib := roots[0], roots[1], roots[2], roots[3]
+
+	// Same feature name defined both in the legacy default dir and in a
+	// same-named component; the component must win, with a warning logged.
+	writeFeatureFixture(t, filepath.Join(usrLib, "sysupdate.d"), "docker", false)
+	writeFeatureFixture(t, filepath.Join(usrLib, "sysupdate.docker.d"), "docker", true)
+
+	features, warnings, err := LoadAllFeatures("")
+	if err != nil {
+		t.Fatalf("LoadAllFeatures() error = %v", err)
+	}
+	if len(features) != 1 {
+		t.Fatalf("expected 1 feature after collision resolution, got %d", len(features))
+	}
+	if !features[0].Enabled {
+		t.Errorf("expected the component's feature (Enabled=true) to win over the default directory's, got Enabled=%v", features[0].Enabled)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 collision warning, got %d: %v", len(warnings), warnings)
+	}
+	if !containsAll(warnings[0], "docker", "default directory", `component "docker"`) {
+		t.Errorf("warning %q missing expected details", warnings[0])
+	}
+}
+
+func TestLoadAllFeatures_CustomPathBypassesDiscovery(t *testing.T) {
+	roots := withTestSearchRoots(t)
+	_, _, _, usrLib := roots[0], roots[1], roots[2], roots[3]
+
+	// A component exists in the standard hierarchy...
+	writeFeatureFixture(t, filepath.Join(usrLib, "sysupdate.docker.d"), "docker", true)
+
+	// ...but an explicit --definitions directory must be used verbatim, with
+	// no discovery and no warnings.
+	customDir := t.TempDir()
+	writeFeatureFixture(t, customDir, "custom", true)
+
+	features, warnings, err := LoadAllFeatures(customDir)
+	if err != nil {
+		t.Fatalf("LoadAllFeatures() error = %v", err)
+	}
+	if warnings != nil {
+		t.Errorf("expected no warnings with customPath, got %v", warnings)
+	}
+	if len(features) != 1 || features[0].Name != "custom" {
+		t.Fatalf("expected only the custom-dir feature, got %+v", features)
+	}
+}
+
+func TestLoadAllTransfers_UnionSkipsNonSysextAndReportsCollisions(t *testing.T) {
+	roots := withTestSearchRoots(t)
+	_, _, _, usrLib := roots[0], roots[1], roots[2], roots[3]
+
+	defaultDir := filepath.Join(usrLib, "sysupdate.d")
+	// Native-image legacy directory: one sysext transfer plus the two
+	// non-sysext OS transfer shapes that must be silently skipped.
+	writeSysextTransferFixture(t, defaultDir, "docker", "default")
+	writePartitionTransferFixture(t, defaultDir, "10-root-verity")
+	writeUKITransferFixture(t, defaultDir, "90-uki")
+
+	// A migrated component ships its own copy of docker (collides with the
+	// legacy default and must win) plus a brand-new incus transfer.
+	writeSysextTransferFixture(t, filepath.Join(usrLib, "sysupdate.docker.d"), "docker", "component")
+	writeSysextTransferFixture(t, filepath.Join(usrLib, "sysupdate.incus.d"), "incus", "component")
+
+	transfers, warnings, err := LoadAllTransfers("")
+	if err != nil {
+		t.Fatalf("LoadAllTransfers() error = %v", err)
+	}
+
+	if len(transfers) != 2 {
+		names := make([]string, len(transfers))
+		for i, tr := range transfers {
+			names[i] = tr.Component
+		}
+		t.Fatalf("expected 2 sysext transfers (partition/UKI skipped), got %d: %v", len(transfers), names)
+	}
+	if transfers[0].Component != "docker" || transfers[1].Component != "incus" {
+		t.Errorf("unexpected transfer set: %q, %q", transfers[0].Component, transfers[1].Component)
+	}
+
+	// The component's copy of docker must have won.
+	if got, want := transfers[0].Source.Path, "https://example.com/component/docker"; got != want {
+		t.Errorf("docker Source.Path = %q, want %q (component copy should win)", got, want)
+	}
+
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 collision warning, got %d: %v", len(warnings), warnings)
+	}
+	if !containsAll(warnings[0], "docker", "default directory", `component "docker"`) {
+		t.Errorf("warning %q missing expected details", warnings[0])
+	}
+}
+
+// TestLoadComponentFeatures_DropInOverrideScoped proves that a component's
+// own highest-priority-root drop-in (the temp-root stand-in for /etc, what
+// updex.Client.writeFeatureDropIn writes to via config.EtcComponentDir)
+// overrides its lower-priority-root base feature file, and that a drop-in
+// placed under a DIFFERENT component's directory has no effect — scoping is
+// respected on read, not just on write.
+func TestLoadComponentFeatures_DropInOverrideScoped(t *testing.T) {
+	roots := withTestSearchRoots(t)
+	etcStandIn, _, _, usrLib := roots[0], roots[1], roots[2], roots[3]
+
+	// Base feature file for the "docker" component, disabled by default.
+	writeFeatureFixture(t, filepath.Join(usrLib, "sysupdate.docker.d"), "docker", false)
+
+	// A drop-in override under a DIFFERENT (legacy default) scope must be
+	// ignored when loading the "docker" component.
+	misplacedDropInDir := filepath.Join(usrLib, "sysupdate.d", "docker.feature.d")
+	if err := os.MkdirAll(misplacedDropInDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(misplacedDropInDir, "00-updex.conf"), []byte("[Feature]\nEnabled=true\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	features, err := LoadComponentFeatures("docker")
+	if err != nil {
+		t.Fatalf("LoadComponentFeatures(\"docker\") error = %v", err)
+	}
+	if len(features) != 1 {
+		t.Fatalf("expected 1 feature, got %d", len(features))
+	}
+	if features[0].Enabled {
+		t.Fatalf("expected the misplaced default-scope drop-in to be ignored, got Enabled=true")
+	}
+
+	// Now write the drop-in at the CORRECT component-scoped path under the
+	// highest-priority root (the /etc stand-in).
+	correctDropInDir := filepath.Join(etcStandIn, "sysupdate.docker.d", "docker.feature.d")
+	if err := os.MkdirAll(correctDropInDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(correctDropInDir, "00-updex.conf"), []byte("[Feature]\nEnabled=true\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	features, err = LoadComponentFeatures("docker")
+	if err != nil {
+		t.Fatalf("LoadComponentFeatures(\"docker\") error = %v", err)
+	}
+	if len(features) != 1 {
+		t.Fatalf("expected 1 feature, got %d", len(features))
+	}
+	if !features[0].Enabled {
+		t.Errorf("expected the component-scoped drop-in to win, got Enabled=false")
+	}
+	if features[0].FilePath != filepath.Join(usrLib, "sysupdate.docker.d", "docker.feature") {
+		t.Errorf("FilePath = %q, unexpected source", features[0].FilePath)
+	}
+}
+
+func TestLoadAllTransfers_CustomPathFiltersNonSysext(t *testing.T) {
+	customDir := t.TempDir()
+	writeSysextTransferFixture(t, customDir, "docker", "custom")
+	writePartitionTransferFixture(t, customDir, "10-root-verity")
+
+	transfers, warnings, err := LoadAllTransfers(customDir)
+	if err != nil {
+		t.Fatalf("LoadAllTransfers() error = %v", err)
+	}
+	if warnings != nil {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+	if len(transfers) != 1 || transfers[0].Component != "docker" {
+		t.Fatalf("expected only the sysext transfer, got %+v", transfers)
+	}
+}
+
+// containsAll reports whether s contains every substring in subs.
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if !strings.Contains(s, sub) {
+			return false
+		}
+	}
+	return true
+}

--- a/config/feature.go
+++ b/config/feature.go
@@ -26,16 +26,95 @@ type Feature struct {
 	Transfers     []string // Names of transfers belonging to this feature
 }
 
-// LoadFeatures loads all .feature files from the specified directory or default paths
+// LoadFeatures loads all .feature files from the specified directory or the
+// legacy default search paths (/etc/sysupdate.d, /run/sysupdate.d, ...). It
+// does not discover named components; see LoadAllFeatures and
+// LoadComponentFeatures for that.
 func LoadFeatures(customPath string) ([]*Feature, error) {
-	var searchPaths []string
-
 	if customPath != "" {
-		searchPaths = []string{customPath}
-	} else {
-		searchPaths = defaultSearchPaths
+		return loadFeaturesFromPaths([]string{customPath})
+	}
+	return loadFeaturesFromPaths(defaultSearchPaths())
+}
+
+// LoadComponentFeatures loads .feature files for a single named component,
+// following its own /etc > /run > /usr/local/lib > /usr/lib precedence (see
+// ComponentSearchPaths). Pass "" for the legacy default component.
+func LoadComponentFeatures(name string) ([]*Feature, error) {
+	return loadFeaturesFromPaths(ComponentSearchPaths(name))
+}
+
+// LoadAllFeatures loads the feature domain updex operates on by default:
+// the union of the legacy default sysupdate.d directory and every
+// discovered named component (see DiscoverComponents). If customPath is
+// non-empty, component discovery is bypassed entirely and this behaves like
+// LoadFeatures(customPath), matching the explicit single-directory override
+// semantics of the --definitions flag.
+//
+// Feature names are expected to be globally unique across the union, since
+// they're derived from distinct sysext names. When the same name is defined
+// by more than one source, the most specific source wins — a named
+// component beats the legacy default directory, and among colliding
+// components the alphabetically last one wins — and the collision is
+// reported as a warning string rather than an error.
+func LoadAllFeatures(customPath string) ([]*Feature, []string, error) {
+	if customPath != "" {
+		f, err := LoadFeatures(customPath)
+		return f, nil, err
 	}
 
+	legacy, err := LoadFeatures("")
+	if err != nil {
+		return nil, nil, err
+	}
+	components, err := DiscoverComponents()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	byName := make(map[string]*Feature)
+	sourceOf := make(map[string]string)
+	var order []string
+	var warnings []string
+
+	put := func(f *Feature, source string) {
+		if prevSource, exists := sourceOf[f.Name]; exists {
+			warnings = append(warnings, fmt.Sprintf(
+				"feature %q defined in both %s and %s; using %s", f.Name, prevSource, source, source))
+		} else {
+			order = append(order, f.Name)
+		}
+		byName[f.Name] = f
+		sourceOf[f.Name] = source
+	}
+
+	for _, f := range legacy {
+		put(f, "the default directory")
+	}
+	for _, comp := range components {
+		cf, err := LoadComponentFeatures(comp.Name)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, f := range cf {
+			put(f, fmt.Sprintf("component %q", comp.Name))
+		}
+	}
+
+	features := make([]*Feature, 0, len(order))
+	for _, name := range order {
+		features = append(features, byName[name])
+	}
+	slices.SortFunc(features, func(a, b *Feature) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+
+	return features, warnings, nil
+}
+
+// loadFeaturesFromPaths loads all .feature files found across searchPaths,
+// with earlier paths taking priority for a given filename.
+func loadFeaturesFromPaths(searchPaths []string) ([]*Feature, error) {
 	// Collect all .feature files, with earlier paths taking priority
 	featureFiles, err := collectConfigFiles(searchPaths, featureSuffix)
 	if err != nil {

--- a/config/transfer.go
+++ b/config/transfer.go
@@ -42,8 +42,9 @@ type SourceSection struct {
 
 // TargetSection represents the [Target] section of a .transfer file
 type TargetSection struct {
-	Type           string   // Target type (regular-file, directory, etc.)
+	Type           string   // Target type (regular-file, directory, partition, etc.)
 	Path           string   // Target directory path
+	PathRelativeTo string   // Base directory Path is relative to (e.g. "boot"); used by non-sysext OS transfers
 	MatchPattern   string   // Primary pattern with @v placeholder for version (first pattern)
 	MatchPatterns  []string // All patterns (for matching different compression formats)
 	CurrentSymlink string   // Optional legacy staging symlink name
@@ -75,24 +76,100 @@ func (t TargetSection) Patterns() []string {
 	return nil
 }
 
-// Default search paths for .transfer files (in priority order)
-var defaultSearchPaths = []string{
-	"/etc/sysupdate.d",
-	"/run/sysupdate.d",
-	"/usr/local/lib/sysupdate.d",
-	"/usr/lib/sysupdate.d",
+// LoadTransfers loads all .transfer files from the specified directory or
+// the legacy default search paths (/etc/sysupdate.d, /run/sysupdate.d, ...).
+// It does not discover named components or filter non-sysext transfers; see
+// LoadAllTransfers and LoadComponentTransfers for that.
+func LoadTransfers(customPath string) ([]*Transfer, error) {
+	if customPath != "" {
+		return loadTransfersFromPaths([]string{customPath})
+	}
+	return loadTransfersFromPaths(defaultSearchPaths())
 }
 
-// LoadTransfers loads all .transfer files from the specified directory or default paths
-func LoadTransfers(customPath string) ([]*Transfer, error) {
-	var searchPaths []string
+// LoadComponentTransfers loads .transfer files for a single named component,
+// following its own /etc > /run > /usr/local/lib > /usr/lib precedence (see
+// ComponentSearchPaths). Pass "" for the legacy default component. It does
+// not filter non-sysext transfers; see FilterSysextTransfers.
+func LoadComponentTransfers(name string) ([]*Transfer, error) {
+	return loadTransfersFromPaths(ComponentSearchPaths(name))
+}
 
+// LoadAllTransfers loads the transfer domain updex operates on by default:
+// the union of the legacy default sysupdate.d directory and every
+// discovered named component (see DiscoverComponents), keeping only
+// sysext-shaped transfers (see FilterSysextTransfers). If customPath is
+// non-empty, component discovery is bypassed entirely and this behaves like
+// LoadTransfers(customPath) with the sysext filter applied, matching the
+// explicit single-directory override semantics of the --definitions flag.
+//
+// Transfer names are expected to be globally unique across the union, since
+// they're derived from distinct sysext names. When the same name is defined
+// by more than one source, the most specific source wins — a named
+// component beats the legacy default directory, and among colliding
+// components the alphabetically last one wins — and the collision is
+// reported as a warning string rather than an error.
+func LoadAllTransfers(customPath string) ([]*Transfer, []string, error) {
 	if customPath != "" {
-		searchPaths = []string{customPath}
-	} else {
-		searchPaths = defaultSearchPaths
+		t, err := LoadTransfers(customPath)
+		if err != nil {
+			return nil, nil, err
+		}
+		return FilterSysextTransfers(t), nil, nil
 	}
 
+	legacy, err := LoadTransfers("")
+	if err != nil {
+		return nil, nil, err
+	}
+	components, err := DiscoverComponents()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	byName := make(map[string]*Transfer)
+	sourceOf := make(map[string]string)
+	var order []string
+	var warnings []string
+
+	put := func(t *Transfer, source string) {
+		if prevSource, exists := sourceOf[t.Component]; exists {
+			warnings = append(warnings, fmt.Sprintf(
+				"transfer %q defined in both %s and %s; using %s", t.Component, prevSource, source, source))
+		} else {
+			order = append(order, t.Component)
+		}
+		byName[t.Component] = t
+		sourceOf[t.Component] = source
+	}
+
+	for _, t := range FilterSysextTransfers(legacy) {
+		put(t, "the default directory")
+	}
+	for _, comp := range components {
+		ct, err := LoadComponentTransfers(comp.Name)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, t := range FilterSysextTransfers(ct) {
+			put(t, fmt.Sprintf("component %q", comp.Name))
+		}
+	}
+
+	transfers := make([]*Transfer, 0, len(order))
+	for _, name := range order {
+		transfers = append(transfers, byName[name])
+	}
+	slices.SortFunc(transfers, func(a, b *Transfer) int {
+		return cmp.Compare(a.Component, b.Component)
+	})
+
+	return transfers, warnings, nil
+}
+
+// loadTransfersFromPaths loads all .transfer files found across
+// searchPaths, with earlier paths taking priority for a given filename.
+func loadTransfersFromPaths(searchPaths []string) ([]*Transfer, error) {
 	// Collect all .transfer files, with earlier paths taking priority
 	transferFiles, err := collectConfigFiles(searchPaths, transferSuffix)
 	if err != nil {
@@ -120,6 +197,39 @@ func LoadTransfers(customPath string) ([]*Transfer, error) {
 	})
 
 	return transfers, nil
+}
+
+// IsSysextTransfer reports whether t has the shape updex supports: a
+// url-file source downloaded to a regular-file target inside an extensions
+// staging directory. Native OS images share the legacy default sysupdate.d
+// directory with non-sysext transfers — GPT "partition" targets for the A/B
+// root, and a "regular-file" target relative to the ESP for the UKI (see
+// sysupdate.d(5), Target's PathRelativeTo=) — which updex must ignore
+// rather than fail on.
+func IsSysextTransfer(t *Transfer) bool {
+	if t.Source.Type != "url-file" {
+		return false
+	}
+	if t.Target.Type != "" && t.Target.Type != "regular-file" {
+		return false
+	}
+	if t.Target.PathRelativeTo != "" {
+		return false
+	}
+	return true
+}
+
+// FilterSysextTransfers returns the subset of transfers that are
+// sysext-shaped url-file-to-regular-file transfers (see IsSysextTransfer),
+// silently dropping OS transfers such as A/B partition updates or the UKI.
+func FilterSysextTransfers(transfers []*Transfer) []*Transfer {
+	var filtered []*Transfer
+	for _, t := range transfers {
+		if IsSysextTransfer(t) {
+			filtered = append(filtered, t)
+		}
+	}
+	return filtered
 }
 
 func parseTransferFile(filePath, component string, specCtx *specifierContext) (*Transfer, error) {
@@ -194,6 +304,9 @@ func parseTransferFile(filePath, component string, specCtx *specifierContext) (*
 		}
 		if key, err := sec.GetKey("Path"); err == nil {
 			t.Target.Path = key.String()
+		}
+		if key, err := sec.GetKey("PathRelativeTo"); err == nil {
+			t.Target.PathRelativeTo = key.String()
 		}
 		if key, err := sec.GetKey("MatchPattern"); err == nil {
 			// Handle multiple patterns (space-separated alternatives).

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/frostyard/updex
 
-go 1.26
+go 1.26.5
 
 require (
 	github.com/ProtonMail/go-crypto v1.4.1

--- a/updex/domain.go
+++ b/updex/domain.go
@@ -1,0 +1,132 @@
+package updex
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/frostyard/updex/config"
+)
+
+// FeaturesOptions configures the Features listing operation.
+type FeaturesOptions struct {
+	// Component scopes the listing to a single named systemd-sysupdate
+	// component (see sysupdate.d(5) "Components"). Empty lists the default
+	// domain: the union of the legacy default sysupdate.d directory and
+	// every discovered component.
+	Component string
+}
+
+// loadDomain resolves the feature/transfer domain a client operation should
+// run over:
+//
+//   - If the client has a Definitions override (--definitions/-C), that
+//     single directory is used verbatim, exactly as before component
+//     support existed. component must be empty in this case.
+//   - Else if component is non-empty, only that named component's own
+//     search paths are used (see config.ComponentSearchPaths).
+//   - Else (the default), the domain is the union of the legacy default
+//     sysupdate.d directory and every discovered component (see
+//     config.LoadAllFeatures / config.LoadAllTransfers). Any name
+//     collisions encountered while building the union are logged as
+//     warnings through the client's reporter.
+//
+// Transfers are always filtered to sysext-shaped url-file-to-regular-file
+// transfers (see config.FilterSysextTransfers), so OS transfers such as A/B
+// partition updates or the UKI that share the legacy default directory on
+// native images are never surfaced.
+func (c *Client) loadDomain(component string) ([]*config.Feature, []*config.Transfer, error) {
+	if c.config.Definitions != "" {
+		if component != "" {
+			return nil, nil, fmt.Errorf("cannot combine --definitions with --component")
+		}
+
+		features, err := config.LoadFeatures(c.config.Definitions)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to load features: %w", err)
+		}
+		transfers, err := config.LoadTransfers(c.config.Definitions)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to load transfers: %w", err)
+		}
+		return features, config.FilterSysextTransfers(transfers), nil
+	}
+
+	if component != "" {
+		features, err := config.LoadComponentFeatures(component)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to load features for component %q: %w", component, err)
+		}
+		transfers, err := config.LoadComponentTransfers(component)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to load transfers for component %q: %w", component, err)
+		}
+		return features, config.FilterSysextTransfers(transfers), nil
+	}
+
+	features, featureWarnings, err := config.LoadAllFeatures("")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to load features: %w", err)
+	}
+	transfers, transferWarnings, err := config.LoadAllTransfers("")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to load transfers: %w", err)
+	}
+	for _, w := range featureWarnings {
+		c.warn("%s", w)
+	}
+	for _, w := range transferWarnings {
+		c.warn("%s", w)
+	}
+
+	return features, transfers, nil
+}
+
+// ComponentInfo describes a discovered systemd-sysupdate component.
+type ComponentInfo struct {
+	// Name is the component name, e.g. "docker" for sysupdate.docker.d.
+	Name string `json:"name"`
+	// SourceDir is the highest-priority existing search-path directory for
+	// this component (see config.Component.SearchPaths).
+	SourceDir string `json:"source_dir"`
+	// FeatureCount is the number of .feature files defined by this
+	// component alone (not counting union collisions with other sources).
+	FeatureCount int `json:"feature_count"`
+}
+
+// Components lists the systemd-sysupdate components discovered on the
+// system (see sysupdate.d(5) "Components"): every sysupdate.<name>.d
+// directory found under the standard search roots. It does not include the
+// legacy default sysupdate.d directory itself; use Features with the
+// default (empty) Component to see the full union domain, including
+// anything still defined there.
+func (c *Client) Components(ctx context.Context) ([]ComponentInfo, error) {
+	c.msg("Discovering components")
+
+	components, err := config.DiscoverComponents()
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover components: %w", err)
+	}
+
+	infos := make([]ComponentInfo, 0, len(components))
+	for _, comp := range components {
+		features, err := config.LoadComponentFeatures(comp.Name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load features for component %q: %w", comp.Name, err)
+		}
+
+		var sourceDir string
+		if len(comp.SearchPaths) > 0 {
+			sourceDir = comp.SearchPaths[0]
+		}
+
+		infos = append(infos, ComponentInfo{
+			Name:         comp.Name,
+			SourceDir:    sourceDir,
+			FeatureCount: len(features),
+		})
+	}
+
+	c.msg("Found %d component(s)", len(infos))
+
+	return infos, nil
+}

--- a/updex/domain_test.go
+++ b/updex/domain_test.go
@@ -1,0 +1,307 @@
+package updex
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/frostyard/updex/config"
+	"github.com/frostyard/updex/sysext"
+)
+
+// withComponentSearchRoots points config.SearchRoots at four fresh temp
+// directories (mimicking /etc, /run, /usr/local/lib, /usr/lib) for the
+// duration of the test, restoring the original value on cleanup. Returns
+// the roots in priority order.
+func withComponentSearchRoots(t *testing.T) []string {
+	t.Helper()
+	root := t.TempDir()
+	roots := []string{
+		filepath.Join(root, "etc"),
+		filepath.Join(root, "run"),
+		filepath.Join(root, "usr", "local", "lib"),
+		filepath.Join(root, "usr", "lib"),
+	}
+	for _, d := range roots {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatalf("failed to create root %s: %v", d, err)
+		}
+	}
+
+	original := config.SearchRoots
+	config.SearchRoots = roots
+	t.Cleanup(func() { config.SearchRoots = original })
+
+	return roots
+}
+
+func writeComponentFeature(t *testing.T, dir, name string, enabled bool) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("failed to create dir %s: %v", dir, err)
+	}
+	enabledStr := "false"
+	if enabled {
+		enabledStr = "true"
+	}
+	content := "[Feature]\nEnabled=" + enabledStr + "\n"
+	if err := os.WriteFile(filepath.Join(dir, name+".feature"), []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write feature file: %v", err)
+	}
+}
+
+func writeComponentTransfer(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("failed to create dir %s: %v", dir, err)
+	}
+	content := `[Transfer]
+Features=` + name + `
+
+[Source]
+Type=url-file
+Path=https://example.com/` + name + `
+MatchPattern=` + name + `_@v.raw
+
+[Target]
+Type=regular-file
+Path=/var/lib/extensions.d
+MatchPattern=` + name + `_@v.raw
+CurrentSymlink=` + name + `.raw
+`
+	if err := os.WriteFile(filepath.Join(dir, name+".transfer"), []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write transfer file: %v", err)
+	}
+}
+
+func writePartitionTransfer(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("failed to create dir %s: %v", dir, err)
+	}
+	content := `[Transfer]
+Verify=yes
+
+[Source]
+Type=url-file
+Path=https://example.com/os
+MatchPattern=cayo_@v.root.raw.xz
+
+[Target]
+Type=partition
+Path=auto
+MatchPattern=cayo_@v_r
+`
+	if err := os.WriteFile(filepath.Join(dir, name+".transfer"), []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write transfer file: %v", err)
+	}
+}
+
+func TestLoadDomain_DefaultIsUnionOfComponents(t *testing.T) {
+	roots := withComponentSearchRoots(t)
+	usrLib := roots[3]
+
+	writeComponentFeature(t, filepath.Join(usrLib, "sysupdate.d"), "shared", true)
+	writeComponentTransfer(t, filepath.Join(usrLib, "sysupdate.d"), "shared")
+
+	writeComponentFeature(t, filepath.Join(usrLib, "sysupdate.docker.d"), "docker", true)
+	writeComponentTransfer(t, filepath.Join(usrLib, "sysupdate.docker.d"), "docker")
+
+	client := NewClient(ClientConfig{})
+	features, transfers, err := client.loadDomain("")
+	if err != nil {
+		t.Fatalf(`loadDomain("") error = %v`, err)
+	}
+	if len(features) != 2 {
+		t.Fatalf("expected 2 features from the union, got %d: %+v", len(features), features)
+	}
+	if len(transfers) != 2 {
+		t.Fatalf("expected 2 transfers from the union, got %d: %+v", len(transfers), transfers)
+	}
+}
+
+func TestLoadDomain_ComponentScoping(t *testing.T) {
+	roots := withComponentSearchRoots(t)
+	usrLib := roots[3]
+
+	writeComponentFeature(t, filepath.Join(usrLib, "sysupdate.d"), "shared", true)
+	writeComponentTransfer(t, filepath.Join(usrLib, "sysupdate.d"), "shared")
+
+	writeComponentFeature(t, filepath.Join(usrLib, "sysupdate.docker.d"), "docker", true)
+	writeComponentTransfer(t, filepath.Join(usrLib, "sysupdate.docker.d"), "docker")
+
+	client := NewClient(ClientConfig{})
+	features, transfers, err := client.loadDomain("docker")
+	if err != nil {
+		t.Fatalf(`loadDomain("docker") error = %v`, err)
+	}
+	if len(features) != 1 || features[0].Name != "docker" {
+		t.Fatalf("expected only the docker feature, got %+v", features)
+	}
+	if len(transfers) != 1 || transfers[0].Component != "docker" {
+		t.Fatalf("expected only the docker transfer, got %+v", transfers)
+	}
+}
+
+func TestLoadDomain_ComponentConflictsWithDefinitions(t *testing.T) {
+	client := NewClient(ClientConfig{Definitions: t.TempDir()})
+	_, _, err := client.loadDomain("docker")
+	if err == nil {
+		t.Fatal("expected an error combining --definitions with --component")
+	}
+}
+
+func TestLoadDomain_SkipsNonSysextTransfersInUnion(t *testing.T) {
+	roots := withComponentSearchRoots(t)
+	usrLib := roots[3]
+
+	defaultDir := filepath.Join(usrLib, "sysupdate.d")
+	writePartitionTransfer(t, defaultDir, "10-root-verity")
+
+	client := NewClient(ClientConfig{})
+	_, transfers, err := client.loadDomain("")
+	if err != nil {
+		t.Fatalf(`loadDomain("") error = %v`, err)
+	}
+	if len(transfers) != 0 {
+		t.Fatalf("expected the partition transfer to be skipped, got %+v", transfers)
+	}
+}
+
+func TestClient_Components(t *testing.T) {
+	roots := withComponentSearchRoots(t)
+	usrLib := roots[3]
+
+	writeComponentFeature(t, filepath.Join(usrLib, "sysupdate.docker.d"), "docker", true)
+	writeComponentFeature(t, filepath.Join(usrLib, "sysupdate.incus.d"), "incus", false)
+	writeComponentFeature(t, filepath.Join(usrLib, "sysupdate.incus.d"), "incus-extra", false)
+
+	client := NewClient(ClientConfig{})
+	components, err := client.Components(t.Context())
+	if err != nil {
+		t.Fatalf("Components() error = %v", err)
+	}
+	if len(components) != 2 {
+		t.Fatalf("expected 2 components, got %d: %+v", len(components), components)
+	}
+	if components[0].Name != "docker" || components[0].FeatureCount != 1 {
+		t.Errorf("docker component = %+v", components[0])
+	}
+	if components[1].Name != "incus" || components[1].FeatureCount != 2 {
+		t.Errorf("incus component = %+v", components[1])
+	}
+	if components[0].SourceDir != filepath.Join(usrLib, "sysupdate.docker.d") {
+		t.Errorf("docker.SourceDir = %q", components[0].SourceDir)
+	}
+}
+
+func TestClient_Components_NoneDiscovered(t *testing.T) {
+	withComponentSearchRoots(t)
+
+	client := NewClient(ClientConfig{})
+	components, err := client.Components(t.Context())
+	if err != nil {
+		t.Fatalf("Components() error = %v", err)
+	}
+	if len(components) != 0 {
+		t.Errorf("expected no components, got %+v", components)
+	}
+}
+
+// TestWriteFeatureDropIn_ComponentScoped verifies the drop-in path a feature
+// resolves to depends on which systemd-sysupdate component it was
+// discovered under (see config.ComponentOfPath): component-scoped features
+// write under /etc/sysupdate.<name>.d/, everything else (legacy default
+// directory or a --definitions override) keeps the legacy
+// /etc/sysupdate.d/ path. dryRun=true is used throughout so this never
+// touches the real filesystem.
+func TestWriteFeatureDropIn_ComponentScoped(t *testing.T) {
+	client := NewClient(ClientConfig{})
+
+	tests := []struct {
+		name        string
+		featureName string
+		featureFile string
+		wantDropIn  string
+	}{
+		{
+			name:        "component-scoped feature",
+			featureName: "docker",
+			featureFile: "/usr/lib/sysupdate.docker.d/docker.feature",
+			wantDropIn:  filepath.Join("/etc", "sysupdate.docker.d", "docker.feature.d", "00-updex.conf"),
+		},
+		{
+			name:        "component-scoped feature overridden in /etc",
+			featureName: "docker",
+			featureFile: "/etc/sysupdate.docker.d/docker.feature",
+			wantDropIn:  filepath.Join("/etc", "sysupdate.docker.d", "docker.feature.d", "00-updex.conf"),
+		},
+		{
+			name:        "legacy default directory feature",
+			featureName: "shared",
+			featureFile: "/usr/lib/sysupdate.d/shared.feature",
+			wantDropIn:  filepath.Join("/etc", "sysupdate.d", "shared.feature.d", "00-updex.conf"),
+		},
+		{
+			name:        "--definitions override directory",
+			featureName: "custom",
+			featureFile: "/tmp/my-custom-dir/custom.feature",
+			wantDropIn:  filepath.Join("/etc", "sysupdate.d", "custom.feature.d", "00-updex.conf"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &config.Feature{
+				Name:     tc.featureName,
+				FilePath: tc.featureFile,
+			}
+			got, err := client.writeFeatureDropIn(f, true, true /* dryRun */)
+			if err != nil {
+				t.Fatalf("writeFeatureDropIn() error = %v", err)
+			}
+			if got != tc.wantDropIn {
+				t.Errorf("writeFeatureDropIn() = %q, want %q", got, tc.wantDropIn)
+			}
+		})
+	}
+}
+
+// TestEnableFeature_ComponentScoping verifies --component scoping end to
+// end: enabling a feature that only exists in the "docker" component
+// succeeds when scoped to that component, and fails with "not found" when
+// scoped to a different (or no matching) component.
+func TestEnableFeature_ComponentScoping(t *testing.T) {
+	roots := withComponentSearchRoots(t)
+	usrLib := roots[3]
+
+	writeComponentFeature(t, filepath.Join(usrLib, "sysupdate.docker.d"), "docker", false)
+	writeComponentTransfer(t, filepath.Join(usrLib, "sysupdate.docker.d"), "docker")
+
+	client := NewClient(ClientConfig{SysextRunner: &sysext.MockRunner{}})
+
+	t.Run("scoped to the right component", func(t *testing.T) {
+		result, err := client.EnableFeature(t.Context(), "docker", EnableFeatureOptions{
+			DryRun:    true,
+			Component: "docker",
+		})
+		if err != nil {
+			t.Fatalf("EnableFeature failed: %v", err)
+		}
+		if !result.Success {
+			t.Errorf("expected Success=true, got false (Error: %s)", result.Error)
+		}
+	})
+
+	t.Run("scoped to an unrelated component", func(t *testing.T) {
+		writeComponentFeature(t, filepath.Join(usrLib, "sysupdate.incus.d"), "incus", false)
+
+		_, err := client.EnableFeature(t.Context(), "docker", EnableFeatureOptions{
+			DryRun:    true,
+			Component: "incus",
+		})
+		if err == nil {
+			t.Fatal("expected an error enabling a feature outside the scoped component")
+		}
+	})
+}

--- a/updex/features.go
+++ b/updex/features.go
@@ -14,23 +14,17 @@ import (
 )
 
 // Features returns all configured features with their status.
-func (c *Client) Features(ctx context.Context) ([]FeatureInfo, error) {
+func (c *Client) Features(ctx context.Context, opts FeaturesOptions) ([]FeatureInfo, error) {
 	c.msg("Loading configurations")
 
-	features, err := config.LoadFeatures(c.config.Definitions)
+	features, transfers, err := c.loadDomain(opts.Component)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load features: %w", err)
+		return nil, err
 	}
 
 	if len(features) == 0 {
 		c.msg("No features configured")
 		return []FeatureInfo{}, nil
-	}
-
-	// Load transfers to show which belong to each feature
-	transfers, err := config.LoadTransfers(c.config.Definitions)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load transfers: %w", err)
 	}
 
 	var featureInfos []FeatureInfo
@@ -60,15 +54,11 @@ func (c *Client) Features(ctx context.Context) ([]FeatureInfo, error) {
 	return featureInfos, nil
 }
 
-// findFeature loads all features and returns the one matching name. It returns
-// an error if the feature is not found or is masked. The action parameter
-// (e.g. "enabled", "disabled") is used in the masked error message.
-func (c *Client) findFeature(name, action string) (*config.Feature, error) {
-	features, err := config.LoadFeatures(c.config.Definitions)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load features: %w", err)
-	}
-
+// lookupFeature returns the feature matching name from an already-loaded
+// feature set. It returns an error if the feature is not found or is
+// masked. The action parameter (e.g. "enabled", "disabled") is used in the
+// masked error message.
+func lookupFeature(features []*config.Feature, name, action string) (*config.Feature, error) {
 	for _, f := range features {
 		if f.Name == name {
 			if f.Masked {
@@ -81,22 +71,17 @@ func (c *Client) findFeature(name, action string) (*config.Feature, error) {
 	return nil, fmt.Errorf("feature '%s' not found", name)
 }
 
-// loadFeatureTransfers loads all transfers and returns those associated with
-// the given feature name.
-func (c *Client) loadFeatureTransfers(name string) ([]*config.Transfer, error) {
-	transfers, err := config.LoadTransfers(c.config.Definitions)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load transfers: %w", err)
-	}
-
-	return config.GetTransfersForFeature(transfers, name), nil
-}
-
 // writeFeatureDropIn creates a drop-in configuration file that sets a
-// feature's enabled state. In dry-run mode it only logs what would happen
-// and returns the path without writing anything.
-func (c *Client) writeFeatureDropIn(name string, enabled bool, dryRun bool) (string, error) {
-	dropInDir := filepath.Join("/etc/sysupdate.d", name+".feature.d")
+// feature's enabled state. The drop-in is written under the same
+// systemd-sysupdate component scope the feature file itself was discovered
+// under (see config.ComponentOfPath): component-scoped features get
+// /etc/sysupdate.<name>.d/..., legacy default and --definitions-loaded
+// features keep the legacy /etc/sysupdate.d/... path. In dry-run mode it
+// only logs what would happen and returns the path without writing
+// anything.
+func (c *Client) writeFeatureDropIn(f *config.Feature, enabled bool, dryRun bool) (string, error) {
+	component, _ := config.ComponentOfPath(f.FilePath) // "" for the legacy default or a --definitions override
+	dropInDir := filepath.Join(config.EtcComponentDir(component), f.Name+".feature.d")
 	dropInFile := filepath.Join(dropInDir, "00-updex.conf")
 
 	if dryRun {
@@ -127,15 +112,23 @@ func (c *Client) EnableFeature(ctx context.Context, name string, opts EnableFeat
 		DryRun:  opts.DryRun,
 	}
 
+	features, transfers, err := c.loadDomain(opts.Component)
+	if err != nil {
+		result.Error = err.Error()
+		c.warn("%s", result.Error)
+		return result, err
+	}
+
 	// Verify the feature exists and is not masked
-	if _, err := c.findFeature(name, "enabled"); err != nil {
+	f, err := lookupFeature(features, name, "enabled")
+	if err != nil {
 		result.Error = err.Error()
 		c.warn("%s", result.Error)
 		return result, err
 	}
 
 	// Create drop-in directory and file
-	dropInFile, err := c.writeFeatureDropIn(name, true, opts.DryRun)
+	dropInFile, err := c.writeFeatureDropIn(f, true, opts.DryRun)
 	if err != nil {
 		result.Error = err.Error()
 		c.warn("%s", result.Error)
@@ -149,12 +142,7 @@ func (c *Client) EnableFeature(ctx context.Context, name string, opts EnableFeat
 	if opts.Now {
 		c.msg("Downloading extensions")
 
-		featureTransfers, err := c.loadFeatureTransfers(name)
-		if err != nil {
-			result.Error = err.Error()
-			c.warn("%s", result.Error)
-			return result, err
-		}
+		featureTransfers := config.GetTransfersForFeature(transfers, name)
 
 		if len(featureTransfers) == 0 {
 			c.msg("No transfers associated with this feature")
@@ -222,20 +210,23 @@ func (c *Client) DisableFeature(ctx context.Context, name string, opts DisableFe
 		DryRun:  opts.DryRun,
 	}
 
-	// Verify the feature exists and is not masked
-	if _, err := c.findFeature(name, "disabled"); err != nil {
-		result.Error = err.Error()
-		c.warn("%s", result.Error)
-		return result, err
-	}
-
-	// Load transfers for this feature (needed for merge state check and file removal)
-	featureTransfers, err := c.loadFeatureTransfers(name)
+	features, transfers, err := c.loadDomain(opts.Component)
 	if err != nil {
 		result.Error = err.Error()
 		c.warn("%s", result.Error)
 		return result, err
 	}
+
+	// Verify the feature exists and is not masked
+	f, err := lookupFeature(features, name, "disabled")
+	if err != nil {
+		result.Error = err.Error()
+		c.warn("%s", result.Error)
+		return result, err
+	}
+
+	// Transfers for this feature (needed for merge state check and file removal)
+	featureTransfers := config.GetTransfersForFeature(transfers, name)
 
 	willRemoveFiles := opts.Now
 
@@ -271,7 +262,7 @@ func (c *Client) DisableFeature(ctx context.Context, name string, opts DisableFe
 	}
 
 	// Create drop-in directory and file
-	dropInFile, err := c.writeFeatureDropIn(name, false, opts.DryRun)
+	dropInFile, err := c.writeFeatureDropIn(f, false, opts.DryRun)
 	if err != nil {
 		result.Error = err.Error()
 		c.warn("%s", result.Error)
@@ -356,14 +347,9 @@ func (c *Client) DisableFeature(ctx context.Context, name string, opts DisableFe
 
 // UpdateFeatures downloads and installs new versions for all enabled features.
 func (c *Client) UpdateFeatures(ctx context.Context, opts UpdateFeaturesOptions) ([]UpdateFeaturesResult, error) {
-	features, err := config.LoadFeatures(c.config.Definitions)
+	features, transfers, err := c.loadDomain(opts.Component)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load features: %w", err)
-	}
-
-	transfers, err := config.LoadTransfers(c.config.Definitions)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load transfers: %w", err)
+		return nil, err
 	}
 
 	var allResults []UpdateFeaturesResult
@@ -462,14 +448,9 @@ func (c *Client) UpdateFeatures(ctx context.Context, opts UpdateFeaturesOptions)
 
 // CheckFeatures checks if newer versions are available for all enabled features.
 func (c *Client) CheckFeatures(ctx context.Context, opts CheckFeaturesOptions) ([]CheckFeaturesResult, error) {
-	features, err := config.LoadFeatures(c.config.Definitions)
+	features, transfers, err := c.loadDomain(opts.Component)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load features: %w", err)
-	}
-
-	transfers, err := config.LoadTransfers(c.config.Definitions)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load transfers: %w", err)
+		return nil, err
 	}
 
 	var allResults []CheckFeaturesResult

--- a/updex/features.go
+++ b/updex/features.go
@@ -14,10 +14,19 @@ import (
 )
 
 // Features returns all configured features with their status.
-func (c *Client) Features(ctx context.Context, opts FeaturesOptions) ([]FeatureInfo, error) {
+//
+// opts is variadic for backward compatibility: only opts[0] is used, if
+// provided; additional elements are ignored. Callers with no options may
+// omit it entirely.
+func (c *Client) Features(ctx context.Context, opts ...FeaturesOptions) ([]FeatureInfo, error) {
+	var opt FeaturesOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
 	c.msg("Loading configurations")
 
-	features, transfers, err := c.loadDomain(opts.Component)
+	features, transfers, err := c.loadDomain(opt.Component)
 	if err != nil {
 		return nil, err
 	}

--- a/updex/features_test.go
+++ b/updex/features_test.go
@@ -585,7 +585,7 @@ func TestFeatures_ListAllFeatures(t *testing.T) {
 
 	// Act
 	client := NewClient(ClientConfig{Definitions: configDir, SysextRunner: mockRunner})
-	features, err := client.Features(t.Context())
+	features, err := client.Features(t.Context(), FeaturesOptions{})
 
 	// Assert
 	if err != nil {

--- a/updex/features_test.go
+++ b/updex/features_test.go
@@ -583,9 +583,10 @@ func TestFeatures_ListAllFeatures(t *testing.T) {
 	targetDir := t.TempDir()
 	updateTransferTargetPath(t, configDir, targetDir)
 
-	// Act
+	// Act: call with no options at all, exercising the backward-compatible
+	// variadic signature (opts is optional).
 	client := NewClient(ClientConfig{Definitions: configDir, SysextRunner: mockRunner})
-	features, err := client.Features(t.Context(), FeaturesOptions{})
+	features, err := client.Features(t.Context())
 
 	// Assert
 	if err != nil {
@@ -613,6 +614,39 @@ func TestFeatures_ListAllFeatures(t *testing.T) {
 	}
 	if !foundEnabled || !foundDisabled {
 		t.Error("expected to find both features")
+	}
+}
+
+// TestFeatures_VariadicOptions verifies the backward-compatible variadic
+// signature: Features(ctx) works with zero options, Features(ctx, opts)
+// works with exactly one (the pre-existing call form), and when multiple
+// options are passed only the first is honored.
+func TestFeatures_VariadicOptions(t *testing.T) {
+	configDir := t.TempDir()
+	mockRunner := &sysext.MockRunner{}
+
+	createFeatureFile(t, configDir, "feature1", true)
+
+	client := NewClient(ClientConfig{Definitions: configDir, SysextRunner: mockRunner})
+
+	// Zero options: should behave like the zero value (Component == "").
+	if _, err := client.Features(t.Context()); err != nil {
+		t.Fatalf("Features() with no opts failed: %v", err)
+	}
+
+	// One option: the pre-existing call form must still compile and work.
+	if _, err := client.Features(t.Context(), FeaturesOptions{}); err != nil {
+		t.Fatalf("Features(opts) failed: %v", err)
+	}
+
+	// Multiple options: only the first is used. A non-empty Component on a
+	// Definitions-scoped client is rejected by loadDomain, so passing it
+	// first should surface that error; passing it second should not.
+	if _, err := client.Features(t.Context(), FeaturesOptions{Component: "bogus"}, FeaturesOptions{}); err == nil {
+		t.Error("expected error from first opts element with Component set on a Definitions-scoped client")
+	}
+	if _, err := client.Features(t.Context(), FeaturesOptions{}, FeaturesOptions{Component: "bogus"}); err != nil {
+		t.Errorf("expected second opts element to be ignored, got error: %v", err)
 	}
 }
 

--- a/updex/options.go
+++ b/updex/options.go
@@ -12,10 +12,20 @@ type UpdateFeaturesOptions struct {
 
 	// NoVacuum skips removing old versions after update.
 	NoVacuum bool
+
+	// Component scopes the operation to a single named systemd-sysupdate
+	// component. Empty operates on the default domain: the union of the
+	// legacy default sysupdate.d directory and every discovered component.
+	Component string
 }
 
 // CheckFeaturesOptions configures the CheckFeatures operation.
-type CheckFeaturesOptions struct{}
+type CheckFeaturesOptions struct {
+	// Component scopes the operation to a single named systemd-sysupdate
+	// component. Empty operates on the default domain: the union of the
+	// legacy default sysupdate.d directory and every discovered component.
+	Component string
+}
 
 // EnableFeatureOptions configures the EnableFeature operation.
 type EnableFeatureOptions struct {
@@ -27,6 +37,11 @@ type EnableFeatureOptions struct {
 
 	// NoRefresh skips running systemd-sysext refresh after download.
 	NoRefresh bool
+
+	// Component scopes the operation to a single named systemd-sysupdate
+	// component. Empty operates on the default domain: the union of the
+	// legacy default sysupdate.d directory and every discovered component.
+	Component string
 }
 
 // installTransferOptions configures the installTransfer operation.
@@ -57,4 +72,9 @@ type DisableFeatureOptions struct {
 
 	// NoRefresh skips running systemd-sysext refresh.
 	NoRefresh bool
+
+	// Component scopes the operation to a single named systemd-sysupdate
+	// component. Empty operates on the default domain: the union of the
+	// legacy default sysupdate.d directory and every discovered component.
+	Component string
 }

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -13,6 +13,7 @@ cmd/updex-cli/main.go          Entry point (frostyard/clix bootstrap)
 cmd/updex/root.go               Cobra root command, global flags
 cmd/updex/features.go           features list|enable|disable|update|check
 cmd/updex/features_run.go       Run functions for feature subcommands
+cmd/updex/components.go         components (list discovered systemd-sysupdate components)
 cmd/updex/daemon.go             daemon enable|disable|status (direct systemd timers)
 cmd/updex/client.go             CLI → SDK client factory
 
@@ -20,17 +21,26 @@ updex/                          Public SDK (Client + methods)
   updex.go                      Client struct, NewClient()
   features.go                   Features(), EnableFeature(), DisableFeature(),
                                 UpdateFeatures(), CheckFeatures(),
-                                writeFeatureDropIn() helper
+                                writeFeatureDropIn() helper, lookupFeature() helper
+  domain.go                     loadDomain() — resolves the feature/transfer
+                                domain for every SDK method (Definitions
+                                override vs. one component vs. the default
+                                union); Components(), ComponentInfo, FeaturesOptions
   install.go                    installTransfer() — complete install pipeline
                                 (download, symlink, sysext link, refresh, vacuum)
                                 Reuses parsed patterns from getAvailableVersions
   list.go                       getAvailableVersions() — returns versions,
                                 manifest, and parsed patterns for caller reuse
-  options.go                    Option structs for all operations
+  options.go                    Option structs for all operations (each
+                                feature-related struct carries Component string)
   results.go                    Result structs for all operations
 
 config/                         .transfer and .feature INI file parsing,
                                 search paths, drop-ins, and specifiers
+config/component.go             systemd-sysupdate component discovery
+                                (SearchRoots, ComponentSearchPaths,
+                                DiscoverComponents, ComponentOfPath,
+                                EtcComponentDir) — see "Components" below
 download/                       HTTP download with SHA256 + decompression
 manifest/                       SHA256SUMS manifest fetch/parse + GPG verify
 version/                        Pattern matching (@v placeholder) + version compare
@@ -106,6 +116,95 @@ All core packages (`config`, `version`, `download`, `manifest`, `sysext`, `syste
 
 Only the first occurrence of a given filename is used. The `-C` flag overrides all search paths with a custom directory.
 
+### Components (`config/component.go`)
+
+A systemd-sysupdate "component" (sysupdate.d(5) "Components") is a named
+grouping of `.transfer`/`.feature` files under `sysupdate.<name>.d/`,
+searched across the same four roots (`config.SearchRoots`, a package var —
+overridable in tests the same way `sysext.SysextDir` is) with the same
+priority order as the legacy default `sysupdate.d/` directory. This exists
+because native OS images now put A/B partition and UKI transfers in the
+default directory (see "Non-sysext transfers" below), and package-versioned
+sysext transfers must not share that single systemd-sysupdate version-lock
+scope — moving a sysext's files to its own `sysupdate.<name>.d/` gives it an
+independent versioning scope. `<name>` must match `[a-zA-Z0-9_-]+`;
+dotted/empty names are ignored (not valid components).
+
+Key `config` functions:
+
+- `DiscoverComponents()` — scans `SearchRoots` for `sysupdate.<name>.d/`
+  directories, returns them sorted by name (does **not** include the legacy
+  default component; `SearchPaths` on each result lists only the
+  directories that actually exist, in priority order).
+- `ComponentSearchPaths(name)` — the four search-path directories for a
+  component (`""` = legacy default). `LoadComponentFeatures(name)` /
+  `LoadComponentTransfers(name)` load exactly one component this way.
+- `LoadAllFeatures(customPath)` / `LoadAllTransfers(customPath)` — the
+  **default read domain**: union of the legacy default directory and every
+  discovered component. A name collision (feature or transfer name defined
+  by more than one source) resolves to the most specific source — a named
+  component beats the legacy default directory, and among colliding
+  components the alphabetically last one wins — and is returned as a
+  warning string (not an error) for the caller to log. `customPath != ""`
+  bypasses discovery entirely and behaves like plain
+  `LoadFeatures`/`LoadTransfers(customPath)` (mirrors the `-C`/`--definitions`
+  override semantics: one explicit flat directory, no component concept).
+- `IsSysextTransfer(t)` / `FilterSysextTransfers(transfers)` — see
+  "Non-sysext transfers" below. `LoadAllTransfers` always applies this
+  filter; the plain `LoadTransfers`/`LoadComponentTransfers` loaders do not.
+- `ComponentOfPath(path)` — recovers the component name from a loaded
+  `Feature.FilePath`'s parent directory (`false` for the legacy default or a
+  `-C` override directory). `EtcComponentDir(name)` is the inverse: the
+  `/etc` override directory to write to for a given component.
+
+`updex.Client.loadDomain(component string)` in `updex/domain.go` is the
+single place every SDK method resolves its read domain from, in this order:
+`ClientConfig.Definitions` set → that one directory verbatim (`component`
+must be empty, else an error — the two are mutually exclusive); `component`
+non-empty → `LoadComponentFeatures`/`LoadComponentTransfers(component)`;
+otherwise → `LoadAllFeatures("")`/`LoadAllTransfers("")`, with any collision
+warnings routed through `c.warn` (the client's reporter). Every
+`*FeatureOptions`/`FeaturesOptions` struct carries `Component string` for
+this — extend an options struct for new component-scoped operations, never
+add package-level flag state to the SDK (see uber-go/CLAUDE.md conventions).
+
+`updex.Client.writeFeatureDropIn` uses `config.ComponentOfPath(f.FilePath)`
+to pick the drop-in directory: a feature discovered under a component writes
+to `EtcComponentDir(name)` (`/etc/sysupdate.<name>.d/<feature>.feature.d/`);
+everything else (legacy default or `-C` override) keeps the original
+`/etc/sysupdate.d/<feature>.feature.d/` path. Because `LoadComponentFeatures`
+reads drop-ins from the same component-scoped search paths on read, writes
+and reads always agree on scope without any extra bookkeeping.
+
+`updex.Client.Components(ctx)` (SDK) / `updex components` (CLI) list
+discovered components — name, highest-priority existing source directory,
+and that component's own feature count (not counting union collisions) —
+via `config.DiscoverComponents` + `LoadComponentFeatures` per component. It
+does not include the legacy default component; use `Features` with the
+default (empty) `Component` to see the full union, including anything still
+defined there.
+
+### Non-sysext transfers
+
+The legacy default `sysupdate.d/` directory on native (bootc A/B) images
+also carries the OS's own transfers, which are not sysext-shaped and which
+`config.FilterSysextTransfers` (used by `LoadAllTransfers`) silently drops
+rather than erroring on:
+
+- **A/B root partitions**: `[Target] Type=partition` (`MatchPartitionType=root`
+  / `root-verity`), `Path=auto`.
+- **UKI**: `[Target] Type=regular-file`, `Path=/EFI/Linux`,
+  `PathRelativeTo=boot` — the `PathRelativeTo` key (parsed into
+  `TargetSection.PathRelativeTo`) is the discriminator that separates this
+  from a genuine sysext regular-file target, since both have
+  `Type=regular-file`.
+
+`IsSysextTransfer(t)` requires `Source.Type == "url-file"`, `Target.Type`
+empty-or-`"regular-file"`, and `Target.PathRelativeTo == ""`. Empty
+`Target.Type` is treated as `regular-file` (not filtered) to match every
+existing sysext `.transfer` fixture in this repo, which never sets `Type=`
+explicitly in `[Target]`.
+
 ### File types
 
 See [Configuration Reference](config-reference.md) for detailed format documentation.
@@ -145,7 +244,7 @@ Transfer file values support systemd-style `%` specifiers. See [Configuration Re
 
 ### Feature update (end-to-end)
 
-1. Load all `.feature` and `.transfer` files from search paths
+1. Load all `.feature` and `.transfer` files: by default the union of the legacy default directory and every discovered component (`Client.loadDomain`, see "Components" above), or a single scope when `--component`/`-C` narrows it. Non-sysext transfers (A/B partition, UKI) are filtered out of the default union before this point.
 2. Filter transfers to those matching enabled features
 3. For each transfer:
    - Fetch `SHA256SUMS` manifest from source URL (+ GPG verify if configured); transient network failures during request or body read and HTTP 5xx/429 are retried up to 3 attempts with exponential backoff, while TLS/cert errors, unsupported protocols, 4xx other than 429, and checksum mismatches fail immediately. Manifests are cached by source URL across transfers so that multiple transfers sharing the same source make only one HTTP request
@@ -163,8 +262,8 @@ Transfer file values support systemd-style `%` specifiers. See [Configuration Re
 
 ### Enable/disable feature
 
-- **Enable**: Creates drop-in at `/etc/sysupdate.d/<name>.feature.d/00-updex.conf` setting `Enabled=true`. With `--now`, also downloads extensions immediately.
-- **Disable**: Creates drop-in setting `Enabled=false`. With `--now`, calls `Unmerge()`, removes symlinks from `/var/lib/extensions/`, and deletes all versioned files. `--force` required if extensions are currently active/merged (changes take effect after reboot).
+- **Enable**: Creates drop-in at `/etc/sysupdate.d/<name>.feature.d/00-updex.conf` (or `/etc/sysupdate.<component>.d/<name>.feature.d/00-updex.conf` for a component-scoped feature — see "Components" above) setting `Enabled=true`. With `--now`, also downloads extensions immediately.
+- **Disable**: Creates drop-in setting `Enabled=false` at the same scoped path. With `--now`, calls `Unmerge()`, removes symlinks from `/var/lib/extensions/`, and deletes all versioned files. `--force` required if extensions are currently active/merged (changes take effect after reboot).
 
 ### Auto-update daemon
 
@@ -186,13 +285,21 @@ updex features update                   Download and install new versions
   --no-vacuum                           Skip removing old versions
   --dry-run                             Preview update work without filesystem/sysext changes
 updex features check                    Check for available updates
+  --component <name>                    Scope any features subcommand above to one
+                                         named component (default: default-dir + every
+                                         discovered component); persistent flag on
+                                         `updex features`, mutually exclusive with -C
+
+updex components                        List discovered systemd-sysupdate components
+                                         (name, source dir, feature count)
 
 updex daemon enable                     Install daily auto-update timer
 updex daemon disable                    Remove auto-update timer
 updex daemon status                     Show timer status
 
 Global flags:
-  -C, --definitions <path>              Custom path to config files
+  -C, --definitions <path>              Custom path to config files (bypasses component
+                                         discovery entirely; mutually exclusive with --component)
   --verify                              Enable GPG verification
   --no-refresh                          Skip systemd-sysext refresh
   --json                                Output as JSON (from clix)

--- a/yeti/config-reference.md
+++ b/yeti/config-reference.md
@@ -13,6 +13,25 @@ Searched in priority order (first occurrence of a filename wins):
 
 The `-C` / `--definitions` flag overrides all paths with a single custom directory.
 
+### Components
+
+The four roots above (`/etc`, `/run`, `/usr/local/lib`, `/usr/lib` —
+`config.SearchRoots`) are also searched for named `sysupdate.<name>.d/`
+directories (systemd-sysupdate "components", sysupdate.d(5) "Components"),
+with the same priority order per component: e.g.
+`/etc/sysupdate.docker.d/` overrides `/usr/lib/sysupdate.docker.d/`. `<name>`
+must match `[a-zA-Z0-9_-]+`.
+
+By default (no `-C`/`--definitions`, no `--component`), updex's config
+domain is the **union** of the legacy default `sysupdate.d/` directory above
+and every discovered component. Feature/transfer names are expected to be
+globally unique across that union; a name defined in more than one source
+resolves to the most specific one (a named component beats the legacy
+default directory) and is reported as a warning. `--component=<name>` scopes
+an operation to a single component's own search paths instead. `-C` bypasses
+component discovery entirely and behaves exactly as before components
+existed. See `yeti/OVERVIEW.md` ("Components") for the full design.
+
 ## Feature Files (`.feature`)
 
 Define a named feature that groups one or more transfers.
@@ -99,12 +118,23 @@ Mode=0644
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `Type` | string | — | Target type (`regular-file`, `directory`) |
+| `Type` | string | — | Target type (`regular-file`, `directory`; native OS images also use `partition`, which updex skips — see below) |
 | `Path` | string | `/var/lib/extensions.d` | Staging directory for downloaded versioned files |
+| `PathRelativeTo` | string | — | Base directory `Path` is relative to (e.g. `boot`, used by the UKI's `/EFI/Linux` target); parsed but only meaningful for non-sysext OS transfers, see below |
 | `MatchPattern` | string | — | Filename pattern with `@v` for installed files |
 | `CurrentSymlink` | string | — | Optional legacy staging symlink name; if configured and present, updex removes it during update |
 | `Mode` | uint32 | `0644` | File permissions |
 | `ReadOnly` | bool | `false` | Whether target should be read-only |
+
+### Non-sysext transfers (skipped, not errored)
+
+Native (bootc A/B) images share the legacy default `sysupdate.d/` directory
+between sysext transfers and the OS's own A/B partition and UKI transfers.
+`config.FilterSysextTransfers` (applied by the default union loader,
+`LoadAllTransfers`) keeps only `Source.Type == "url-file"` transfers whose
+target is empty-or-`regular-file` with no `PathRelativeTo` set, silently
+dropping `Target Type=partition` entries and the UKI's
+`Type=regular-file`+`PathRelativeTo=boot` entry rather than erroring on them.
 
 ### Multiple `MatchPattern` values
 

--- a/yeti/sdk-api.md
+++ b/yeti/sdk-api.md
@@ -27,10 +27,41 @@ func NewClient(cfg ClientConfig) *Client
 ### Features
 
 ```go
-func (c *Client) Features(ctx context.Context) ([]FeatureInfo, error)
+func (c *Client) Features(ctx context.Context, opts FeaturesOptions) ([]FeatureInfo, error)
 ```
 
 Lists all configured features with their enabled/masked status and associated transfers.
+
+**FeaturesOptions:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `Component` | `string` | Scope to one named systemd-sysupdate component instead of the default union (see "Component scoping" below); `""` = default |
+
+### Components
+
+```go
+func (c *Client) Components(ctx context.Context) ([]ComponentInfo, error)
+```
+
+Lists discovered systemd-sysupdate components (`sysupdate.<name>.d/` directories, see `config.DiscoverComponents`) — name, highest-priority existing source directory, and that component's own feature count. Does **not** include the legacy default `sysupdate.d/` "component"; call `Features` with the default (empty) `Component` to see the full union.
+
+```go
+type ComponentInfo struct {
+    Name         string `json:"name"`
+    SourceDir    string `json:"source_dir"`
+    FeatureCount int    `json:"feature_count"`
+}
+```
+
+### Component scoping
+
+Every feature-related options struct (`FeaturesOptions`, `EnableFeatureOptions`, `DisableFeatureOptions`, `UpdateFeaturesOptions`, `CheckFeaturesOptions`) carries a `Component string` field. All SDK methods resolve their read/write domain through the unexported `Client.loadDomain(component string)`:
+
+1. `ClientConfig.Definitions` set → load exactly that one directory (as before component support existed); `Component` must be `""` here, otherwise `loadDomain` returns an error (`Definitions` and `Component` are mutually exclusive).
+2. `Component` non-empty → load only that named component's own search paths (`config.LoadComponentFeatures`/`LoadComponentTransfers`).
+3. Otherwise (the default) → the union of the legacy default `sysupdate.d/` directory and every discovered component (`config.LoadAllFeatures`/`LoadAllTransfers`). Any name collision between sources is logged through the client's reporter as a warning (component wins over the legacy default directory), not returned as an error.
+
+In all three cases, transfers are filtered to sysext-shaped ones (`config.FilterSysextTransfers` / `IsSysextTransfer`): a `url-file` source to a `regular-file` target with no `PathRelativeTo`. This drops the non-sysext OS transfers (A/B partition, UKI) that share the legacy default directory on native images.
 
 ### EnableFeature / DisableFeature
 
@@ -43,7 +74,7 @@ Enable creates a drop-in file setting `Enabled=true`. With `Now: true`, it downl
 
 In dry-run mode, enable/disable skip writing drop-ins and skip sysext/filesystem mutations. `EnableFeature` with `Now: true` records associated transfer components as would-download entries without fetching manifests or resolving exact versions. `DisableFeature` with `Now: true` still checks active versions for force-safety, then records component-level would-remove entries instead of deleting files.
 
-Both methods reject missing or masked features before writing drop-ins. Drop-ins are always targeted at `/etc/sysupdate.d/<feature>.feature.d/00-updex.conf`, even when `ClientConfig.Definitions` points at a custom read path; dry-run returns that would-be path but leaves `FeatureActionResult.DropIn` empty because no file was written.
+Both methods reject missing or masked features before writing drop-ins. The drop-in target directory depends on where the feature file was discovered (`config.ComponentOfPath(f.FilePath)`): a feature found under a `sysupdate.<name>.d/` component writes to `/etc/sysupdate.<name>.d/<feature>.feature.d/00-updex.conf` (via `config.EtcComponentDir(name)`); a feature from the legacy default directory or a `ClientConfig.Definitions` override keeps the original `/etc/sysupdate.d/<feature>.feature.d/00-updex.conf` path. Dry-run returns that would-be path but leaves `FeatureActionResult.DropIn` empty because no file was written.
 
 **EnableFeatureOptions:**
 | Field | Type | Description |
@@ -51,6 +82,7 @@ Both methods reject missing or masked features before writing drop-ins. Drop-ins
 | `Now` | `bool` | Download extensions immediately after enabling |
 | `DryRun` | `bool` | Preview without modifying filesystem |
 | `NoRefresh` | `bool` | Skip `systemd-sysext refresh` |
+| `Component` | `string` | Scope to one named component; `""` = default union |
 
 **DisableFeatureOptions:**
 | Field | Type | Description |
@@ -59,6 +91,7 @@ Both methods reject missing or masked features before writing drop-ins. Drop-ins
 | `Force` | `bool` | Allow removal of currently merged extensions (requires reboot) |
 | `DryRun` | `bool` | Preview without modifying filesystem |
 | `NoRefresh` | `bool` | Skip `systemd-sysext refresh` |
+| `Component` | `string` | Scope to one named component; `""` = default union |
 
 ### UpdateFeatures
 
@@ -80,6 +113,7 @@ Already-current components are detected by `sysext.GetInstalledVersions`: the se
 | `DryRun` | `bool` | Preview downloads, installs, refreshes, and vacuum removals without modifying filesystem or sysext state; still fetches manifests and inspects local installed files |
 | `NoRefresh` | `bool` | Skip `systemd-sysext refresh` after updates |
 | `NoVacuum` | `bool` | Skip removing old versions |
+| `Component` | `string` | Scope to one named component; `""` = default union |
 
 ### CheckFeatures
 
@@ -87,7 +121,12 @@ Already-current components are detected by `sysext.GetInstalledVersions`: the se
 func (c *Client) CheckFeatures(ctx context.Context, opts CheckFeaturesOptions) ([]CheckFeaturesResult, error)
 ```
 
-Checks for available updates without downloading. Manifests are cached by source URL, same as `UpdateFeatures`. `CheckFeaturesOptions` is currently empty.
+Checks for available updates without downloading. Manifests are cached by source URL, same as `UpdateFeatures`.
+
+**CheckFeaturesOptions:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `Component` | `string` | Scope to one named component; `""` = default union |
 
 ## Result Types
 
@@ -166,12 +205,25 @@ type CheckResult struct {
 
 ### `config`
 
-- `LoadFeatures(customPath string) ([]*Feature, error)` — Load all `.feature` files
-- `LoadTransfers(customPath string) ([]*Transfer, error)` — Load all `.transfer` files
+- `LoadFeatures(customPath string) ([]*Feature, error)` — Load all `.feature` files from `customPath`, or the legacy default search paths if empty. No component discovery.
+- `LoadTransfers(customPath string) ([]*Transfer, error)` — Load all `.transfer` files from `customPath`, or the legacy default search paths if empty. No component discovery, no sysext-type filtering.
 - `FilterTransfersByFeatures(transfers []*Transfer, features []*Feature) []*Transfer` — Filter transfers to those matching enabled features
 - `GetTransfersForFeature(transfers []*Transfer, featureName string) []*Transfer` — Get transfers associated with a specific feature by membership in `Features` or `RequisiteFeatures`; this is association lookup, not full active-transfer filtering
 - `GetEnabledFeatureNames(features []*Feature) []string`
 - `IsFeatureEnabled(features []*Feature, name string) bool`
+
+**Component discovery** (`config/component.go`; see `yeti/OVERVIEW.md` "Components" for the full design):
+
+- `SearchRoots` — Package variable: `[]string{"/etc", "/run", "/usr/local/lib", "/usr/lib"}`, in priority order. Overridable in tests (same pattern as `sysext.SysextDir`).
+- `ComponentSearchPaths(name string) []string` — The four search-path directories for a component (`""` = legacy default `sysupdate.d/`).
+- `EtcComponentDir(name string) string` — The `/etc` override directory for a component's drop-ins (`""` = `/etc/sysupdate.d`).
+- `type Component struct { Name string; SearchPaths []string }` — `SearchPaths` lists only the directories that exist on disk, in priority order.
+- `DiscoverComponents() ([]Component, error)` — Scan `SearchRoots` for `sysupdate.<name>.d/` directories (`[a-zA-Z0-9_-]+` names; dotted/empty names ignored), sorted by name. Does not include the legacy default component.
+- `LoadComponentFeatures(name string) ([]*Feature, error)` / `LoadComponentTransfers(name string) ([]*Transfer, error)` — Load one named component (`""` = legacy default), following its own search-path precedence.
+- `LoadAllFeatures(customPath string) ([]*Feature, []string, error)` / `LoadAllTransfers(customPath string) ([]*Transfer, []string, error)` — Load the union of the legacy default directory and every discovered component; returns collision-warning strings alongside the result. `customPath != ""` bypasses discovery and behaves like the plain `Load*(customPath)` functions (`LoadAllTransfers` additionally applies `FilterSysextTransfers` in this case). `LoadAllTransfers` always applies `FilterSysextTransfers` to every source before merging.
+- `IsSysextTransfer(t *Transfer) bool` — `true` for a `url-file`-sourced transfer whose target is empty-or-`regular-file` with no `PathRelativeTo` set.
+- `FilterSysextTransfers(transfers []*Transfer) []*Transfer` — Keep only `IsSysextTransfer` matches.
+- `ComponentOfPath(path string) (name string, ok bool)` — Recover the component name from a loaded `Feature`/`Transfer`'s `FilePath` (its parent directory). `ok=false` for the legacy default directory or a `-C`/`Definitions` override directory.
 
 ### `manifest`
 

--- a/yeti/sdk-api.md
+++ b/yeti/sdk-api.md
@@ -27,10 +27,10 @@ func NewClient(cfg ClientConfig) *Client
 ### Features
 
 ```go
-func (c *Client) Features(ctx context.Context, opts FeaturesOptions) ([]FeatureInfo, error)
+func (c *Client) Features(ctx context.Context, opts ...FeaturesOptions) ([]FeatureInfo, error)
 ```
 
-Lists all configured features with their enabled/masked status and associated transfers.
+Lists all configured features with their enabled/masked status and associated transfers. `opts` is variadic for backward compatibility with the pre-component-scoping signature (`Features(ctx)`): only `opts[0]` is read when present, so callers may either omit `opts` entirely or pass a single `FeaturesOptions{}`.
 
 **FeaturesOptions:**
 | Field | Type | Description |


### PR DESCRIPTION
## Summary
- discover and load named systemd-sysupdate component directories alongside legacy definitions
- scope feature operations and drop-ins to their owning component
- filter native OS partition and UKI transfers from sysext workflows

## Validation
- make check
- make build