### PR TITLE
fix: emit JSON [] not null for empty feature check/update results

### DIFF
--- a/cmd/updex/features_run.go
+++ b/cmd/updex/features_run.go
@@ -165,6 +165,13 @@ func runFeaturesUpdate(cmd *cobra.Command, args []string) error {
 	results, err := client.UpdateFeatures(cmd.Context(), opts)
 
 	if clix.JSONOutput {
+		// Never emit JSON `null` on stdout, even on the error path where the
+		// client returns a nil slice (e.g. domain load failure). Consumers
+		// parse this stream and expect an array. The error is still returned
+		// (non-zero exit) via errors.Join below.
+		if results == nil {
+			results = []updex.UpdateFeaturesResult{}
+		}
 		_, jsonErr := clix.OutputJSON(results)
 		return errors.Join(err, jsonErr)
 	}
@@ -208,6 +215,12 @@ func runFeaturesCheck(cmd *cobra.Command, args []string) error {
 	})
 
 	if clix.JSONOutput {
+		// Never emit JSON `null` on stdout, even on the error path where the
+		// client returns a nil slice (e.g. domain load failure). See
+		// runFeaturesUpdate for the same rationale.
+		if results == nil {
+			results = []updex.CheckFeaturesResult{}
+		}
 		_, jsonErr := clix.OutputJSON(results)
 		return errors.Join(err, jsonErr)
 	}

--- a/cmd/updex/features_run_test.go
+++ b/cmd/updex/features_run_test.go
@@ -135,3 +135,63 @@ func TestRunFeaturesUpdate_ThreadsDryRun(t *testing.T) {
 		t.Error("expected CLI dry-run to avoid creating the current symlink")
 	}
 }
+
+// TestRunFeaturesCheck_JSONErrorPathEmitsArray verifies that on the error path
+// (here: --definitions combined with --component, which fails loadDomain), the
+// --json output on stdout is `[]`, never `null`. The command still returns a
+// non-zero error. Regression guard for the null-vs-array contract that broke
+// pilothouse.
+func TestRunFeaturesCheck_JSONErrorPathEmitsArray(t *testing.T) {
+	oldDefinitions, oldComponent, oldJSONOutput := definitions, featureComponent, clix.JSONOutput
+	t.Cleanup(func() {
+		definitions = oldDefinitions
+		featureComponent = oldComponent
+		clix.JSONOutput = oldJSONOutput
+	})
+
+	definitions = t.TempDir()
+	featureComponent = "somecomponent" // combining the two makes loadDomain fail
+	clix.JSONOutput = true
+
+	output, err := captureStdout(t, func() error {
+		cmd := &cobra.Command{}
+		cmd.SetContext(t.Context())
+		return runFeaturesCheck(cmd, nil)
+	})
+	if err == nil {
+		t.Fatal("expected an error on the --definitions + --component path")
+	}
+	if strings.TrimSpace(output) != "[]" {
+		t.Errorf("expected stdout []; got %q", output)
+	}
+}
+
+// TestRunFeaturesUpdate_JSONErrorPathEmitsArray is the update analog. It also
+// sets getEUID to root so the requireRoot() guard is not what fails.
+func TestRunFeaturesUpdate_JSONErrorPathEmitsArray(t *testing.T) {
+	oldDefinitions, oldComponent, oldJSONOutput := definitions, featureComponent, clix.JSONOutput
+	oldGetEUID := getEUID
+	t.Cleanup(func() {
+		definitions = oldDefinitions
+		featureComponent = oldComponent
+		clix.JSONOutput = oldJSONOutput
+		getEUID = oldGetEUID
+	})
+
+	definitions = t.TempDir()
+	featureComponent = "somecomponent"
+	clix.JSONOutput = true
+	getEUID = func() int { return 0 }
+
+	output, err := captureStdout(t, func() error {
+		cmd := &cobra.Command{}
+		cmd.SetContext(t.Context())
+		return runFeaturesUpdate(cmd, nil)
+	})
+	if err == nil {
+		t.Fatal("expected an error on the --definitions + --component path")
+	}
+	if strings.TrimSpace(output) != "[]" {
+		t.Errorf("expected stdout []; got %q", output)
+	}
+}

--- a/updex/features.go
+++ b/updex/features.go
@@ -361,7 +361,10 @@ func (c *Client) UpdateFeatures(ctx context.Context, opts UpdateFeaturesOptions)
 		return nil, err
 	}
 
-	var allResults []UpdateFeaturesResult
+	// Initialize as a non-nil slice so empty results serialize as JSON `[]`
+	// rather than `null`. Consumers (pilothouse, snosi scripts) that parse
+	// the CLI's `--json` output depend on an array being present.
+	allResults := make([]UpdateFeaturesResult, 0)
 	var hasErrors bool
 
 	// Cache manifests by source URL to avoid redundant HTTP requests
@@ -380,6 +383,9 @@ func (c *Client) UpdateFeatures(ctx context.Context, opts UpdateFeaturesOptions)
 
 		featureResult := UpdateFeaturesResult{
 			Feature: f.Name,
+			// Non-nil so a feature with no per-transfer result serializes
+			// its `results` as `[]` rather than `null`.
+			Results: make([]UpdateResult, 0),
 		}
 
 		for _, transfer := range featureTransfers {
@@ -462,7 +468,9 @@ func (c *Client) CheckFeatures(ctx context.Context, opts CheckFeaturesOptions) (
 		return nil, err
 	}
 
-	var allResults []CheckFeaturesResult
+	// Initialize as a non-nil slice so empty results serialize as JSON `[]`
+	// rather than `null` (see UpdateFeatures for the same rationale).
+	allResults := make([]CheckFeaturesResult, 0)
 
 	// Cache manifests by source URL to avoid redundant HTTP requests
 	// when multiple transfers share the same source.
@@ -480,6 +488,9 @@ func (c *Client) CheckFeatures(ctx context.Context, opts CheckFeaturesOptions) (
 
 		featureResult := CheckFeaturesResult{
 			Feature: f.Name,
+			// Non-nil so a feature with no per-transfer result serializes
+			// its `results` as `[]` rather than `null`.
+			Results: make([]CheckResult, 0),
 		}
 
 		for _, transfer := range featureTransfers {

--- a/updex/features_test.go
+++ b/updex/features_test.go
@@ -3,6 +3,7 @@ package updex
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1379,5 +1380,92 @@ func TestCheckFeatures_UpToDate(t *testing.T) {
 	}
 	if results[0].Results[0].UpdateAvailable {
 		t.Error("expected UpdateAvailable=false when up to date")
+	}
+}
+
+// TestCheckFeatures_EmptyResultsSerializeAsArray verifies that when there are
+// no enabled features (or no qualifying results), CheckFeatures returns a
+// non-nil slice that JSON-marshals to `[]` rather than `null`. Consumers such
+// as pilothouse and snosi scripts parse the CLI `--json` output and previously
+// broke on a top-level `null`. See docs in features.go.
+func TestCheckFeatures_EmptyResultsSerializeAsArray(t *testing.T) {
+	configDir := t.TempDir() // empty: no .feature/.transfer files
+
+	client := NewClient(ClientConfig{Definitions: configDir, SysextRunner: &sysext.MockRunner{}})
+	results, err := client.CheckFeatures(t.Context(), CheckFeaturesOptions{})
+	if err != nil {
+		t.Fatalf("CheckFeatures failed: %v", err)
+	}
+	if results == nil {
+		t.Fatal("expected non-nil slice, got nil (would serialize as JSON null)")
+	}
+	b, err := json.Marshal(results)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	if string(b) != "[]" {
+		t.Errorf("expected JSON [], got %s", b)
+	}
+}
+
+// TestUpdateFeatures_EmptyResultsSerializeAsArray is the UpdateFeatures analog
+// of TestCheckFeatures_EmptyResultsSerializeAsArray.
+func TestUpdateFeatures_EmptyResultsSerializeAsArray(t *testing.T) {
+	configDir := t.TempDir() // empty: no .feature/.transfer files
+
+	client := NewClient(ClientConfig{Definitions: configDir, SysextRunner: &sysext.MockRunner{}})
+	results, err := client.UpdateFeatures(t.Context(), UpdateFeaturesOptions{NoRefresh: true})
+	if err != nil {
+		t.Fatalf("UpdateFeatures failed: %v", err)
+	}
+	if results == nil {
+		t.Fatal("expected non-nil slice, got nil (would serialize as JSON null)")
+	}
+	b, err := json.Marshal(results)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	if string(b) != "[]" {
+		t.Errorf("expected JSON [], got %s", b)
+	}
+}
+
+// TestCheckFeatures_NestedResultsSerializeAsArray covers the reachable case
+// where an enabled feature has a transfer but the manifest yields no matching
+// versions: the inner loop `continue`s without appending, so the feature's
+// nested `Results` stays empty. It must serialize as `"results":[]`, not
+// `"results":null`. This protects the load-bearing make([]CheckResult, 0) in
+// CheckFeatures.
+func TestCheckFeatures_NestedResultsSerializeAsArray(t *testing.T) {
+	configDir := t.TempDir()
+	targetDir := t.TempDir()
+
+	// Server offers no files at all -> manifest has zero available versions.
+	server := testutil.NewTestServer(t, testutil.TestServerFiles{
+		Files: map[string]string{},
+	})
+	defer server.Close()
+
+	createFeatureFile(t, configDir, "testfeature", true)
+	createFeatureTransferFile(t, configDir, "testext", "testfeature", server.URL)
+	updateTransferTargetPath(t, configDir, targetDir)
+
+	client := NewClient(ClientConfig{Definitions: configDir, SysextRunner: &sysext.MockRunner{}})
+	results, err := client.CheckFeatures(t.Context(), CheckFeaturesOptions{})
+	if err != nil {
+		t.Fatalf("CheckFeatures failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 feature result, got %d", len(results))
+	}
+	if len(results[0].Results) != 0 {
+		t.Fatalf("expected 0 component results, got %d", len(results[0].Results))
+	}
+	b, err := json.Marshal(results)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	if !strings.Contains(string(b), `"results":[]`) {
+		t.Errorf("expected nested \"results\":[] in output, got %s", b)
 	}
 }


### PR DESCRIPTION
## Summary

`updex features check --json` and `updex features update --json` emitted JSON `null` instead of `[]` when there were no enabled features / no qualifying results. The top-level result slices were declared nil (`var allResults []T`) and returned unchanged; nested per-feature `Results` slices had the same issue.

A downstream consumer (frostyard/pilothouse) broke on the top-level `null` when no sysext updates were available. This is the root-cause fix for that class of bug — documented in frostyard/snosi `docs/integration-contracts.md` §3.1 / §8 #1.

## Changes

- **`updex/features.go`** — initialize the top-level slice in `CheckFeatures` and `UpdateFeatures` with `make([]T, 0)`, and initialize each feature's nested `Results` with `make([]…, 0)`. Empty results now serialize as `[]` uniformly, matching `features list` / `components` which were already correct.
- **`cmd/updex/features_run.go`** — guard the `--json` path so the **error** case (client returns a nil slice on a domain load failure, e.g. `--definitions` + `--component`) also emits `[]` on stdout instead of `null`. The non-zero exit is unchanged. (Found in adversarial review — the fixed bug otherwise survived on the error path.)
- **Tests** — SDK regression tests for the empty top-level case (both functions) and the reachable nested-empty case (`CheckFeatures`, where a transfer with zero available versions leaves `Results` empty); CLI tests asserting the `--json` error path prints `[]` with a non-zero error.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` all clean.
- Manual: `updex -C <empty> --silent features check --json` → `[]`; error path → `[]` with exit 1.

## Notes

`make([]T, 0)` is used for consistency with the existing `Components()` implementation (`domain.go:110`). Non-root `features update` still exits at `requireRoot()` before the JSON block (pre-existing) and leaks nothing to stdout.