### PR TITLE
fix: serialize GoReleaser snapshots

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -12,6 +12,12 @@ on:
 permissions:
   contents: write
 
+# Nightlies replace the same dev tag and release. Cancel stale runs before a
+# newer one publishes so concurrent GoReleaser uploads cannot collide.
+concurrency:
+  group: goreleaser-nightly
+  cancel-in-progress: true
+
 jobs:
   snapshot:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,15 @@ Run a single test: `go test -v -run TestName ./updex/`
 
 End-to-end tests live in `tests/e2e/`: black-box tests that build the real `updex` binary and run it as a subprocess against a fake HTTP transfer source, covering only read-only commands (no root required). Run with `go test -v ./tests/e2e/...`.
 
+## Release Automation
+
+`.github/workflows/snapshot.yml` publishes the singleton GoReleaser nightly
+release under the `dev` tag after successful `main` tests. Its
+`goreleaser-nightly` concurrency group must keep `cancel-in-progress: true`:
+overlapping runs delete and recreate the same release, then collide while
+uploading identically named assets. The newest successful test run supersedes
+older snapshot work.
+
 ## Architecture
 
 updex is a Go SDK and CLI for managing systemd-sysext images. It replicates `systemd-sysupdate` functionality for `url-file` transfers.

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -484,3 +484,13 @@ Mutating commands enforce root before reading `--dry-run`, so examples that prev
 | `github.com/ulikunitz/xz` | XZ decompression |
 | `github.com/klauspost/compress` | ZSTD decompression |
 | `github.com/ProtonMail/go-crypto` | GPG signature verification (openpgp) |
+
+## CI and Releases
+
+`.github/workflows/snapshot.yml` runs after successful `Tests` workflows on
+`main` and publishes a GoReleaser Pro nightly under the singleton `dev` tag.
+GoReleaser's `nightly.keep_single_release` deletes and recreates that release,
+so concurrent runs race while uploading the same artifact names and fail with
+GitHub HTTP 422 `already_exists`. Workflow-level concurrency group
+`goreleaser-nightly` allows only one publisher at a time and cancels stale runs
+so the newest successful test result is the release that survives.


### PR DESCRIPTION
## Summary

- add a workflow-level `goreleaser-nightly` concurrency group to the snapshot publisher
- cancel stale snapshot runs so only the newest successful `main` test result can replace the singleton `dev` release
- document why this concurrency contract must remain in place

This addresses the observed race in [run 31236898330](https://github.com/frostyard/updex/actions/runs/31236898330), where overlapping nightlies recreated the same release and failed asset uploads with HTTP 422 `already_exists`.

## Validation

- `actionlint .github/workflows/snapshot.yml`
- parsed workflow assertion for `group: goreleaser-nightly` and `cancel-in-progress: true`

Closes #159
