### PR TITLE
docs: surface PR review rubric

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,3 +11,5 @@
 
 - [ ] I have described the change clearly.
 - [ ] I have added/updated tests where appropriate.
+- [ ] I have checked this change against the
+  [PR review rubric](https://github.com/frostyard/updex/blob/main/docs/review-rubric.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,10 @@ to rediscover belongs in `yeti/learnings/`.
 6. Open the PR with a description of what changed and why, and link any
    related issue.
 
+Before requesting review, check the change against the
+[pull request review rubric](docs/review-rubric.md). Reviewers use its gates and
+feedback labels to keep decisions consistent and actionable.
+
 CI runs on every pull request (`.github/workflows/test.yml`) and must pass:
 lint (golangci-lint), security scan (`govulncheck`), unit tests with coverage,
 race-detector tests, verification (`go mod tidy` cleanliness, `go vet`,


### PR DESCRIPTION
## Summary

- link the existing PR review rubric from the contributor workflow
- add a PR-template checkbox so authors apply the rubric before requesting review

The rubric was added to `main` by #175 for a duplicate ACMM finding, but was not connected to the normal PR workflow. This makes it visible and actionable for every contribution.

## Testing

- [x] `make fmt`
- [x] `make test`
- [x] `git diff --check`

## Checklist

- [x] I have described the change clearly.
- [x] I have added/updated tests where appropriate.
- [x] I have checked this change against the [PR review rubric](https://github.com/frostyard/updex/blob/main/docs/review-rubric.md).

Closes #163
