### PR TITLE
docs: make PR acceptance metric reproducible

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ changes, update:
 - `yeti/OVERVIEW.md`, `yeti/sdk-api.md`, `yeti/config-reference.md` — the
   agent-oriented architecture, SDK, and configuration references
 - `CLAUDE.md` / `AGENTS.md` — when conventions or the build workflow change
-- `docs/` — topic guides such as `docs/patterns.md`
+- `docs/` — topic guides such as `docs/patterns.md` and `docs/metrics.md`
 
 Durable, non-obvious rationale that future contributors would otherwise have
 to rediscover belongs in `yeti/learnings/`.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -14,3 +14,34 @@ pull requests are excluded. Report the rate monthly from GitHub pull request
 data, using the merge or close date to assign each pull request to a period.
 Track the accepted and closed-unmerged counts alongside the percentage so that
 changes in review volume remain visible.
+
+### Reporting
+
+After each month closes, set the inclusive UTC date range and calculate the
+metric from GitHub:
+
+```bash
+START=2026-07-01
+END=2026-07-31
+
+gh pr list --state all --search "closed:${START}..${END}" --limit 1000 \
+  --json mergedAt |
+  jq '
+    . as $prs
+    | ($prs | map(select(.mergedAt != null)) | length) as $accepted
+    | ($prs | map(select(.mergedAt == null)) | length) as $closed
+    | {
+        accepted: $accepted,
+        closed_unmerged: $closed,
+        acceptance_rate: (
+          if ($accepted + $closed) == 0 then null
+          else (($accepted * 10000 / ($accepted + $closed) | round) / 100)
+          end
+        )
+      }
+  '
+```
+
+The rate is a percentage rounded to two decimal places. A month with no
+resolved pull requests reports `null` rather than a misleading 0% acceptance
+rate.


### PR DESCRIPTION
## Summary

- add a repeatable `gh`/`jq` procedure for the monthly PR acceptance metric
- report accepted and closed-unmerged counts plus a two-decimal percentage
- link the metrics guide from `CONTRIBUTING.md`

PR #174 added the metric definition while closing duplicate issue #173. This follow-up makes that metric actionable and closes the original issue.

Closes #162

## Testing

- [ ] `make fmt` (documentation-only change)
- [ ] `make test` (documentation-only change)
- [x] Ran the documented command against `frostyard/updex`

## Checklist

- [x] I have described the change clearly.
- [x] I have added/updated tests where appropriate.
