### PR TITLE
docs: define session handoff format

### DIFF
--- a/.claude/session-summary.md
+++ b/.claude/session-summary.md
@@ -1,4 +1,32 @@
 # Session summary
 
-Record completed work, verification performed, and any follow-up items here at
-the end of an agent session.
+Use this artifact for concise handoff context that a future agent needs to
+continue unfinished work without reconstructing the previous session.
+
+## How to use it
+
+- Add the newest entry first under **Summaries**.
+- Record the objective, outcome, changed paths, verification, decisions, and
+  concrete follow-up work.
+- Link issues, pull requests, and commits instead of copying long logs or diffs.
+- Never include credentials, tokens, private user data, or raw command output.
+- Move durable architecture decisions and non-obvious lessons to
+  `yeti/learnings/`; this file is for session continuity.
+- Remove the placeholder once the first summary is recorded, and prune entries
+  after their follow-up work is complete or captured in permanent docs.
+
+## Entry template
+
+<!--
+### YYYY-MM-DD — short objective
+
+- **Outcome:** completed, blocked, or in progress
+- **Changed:** paths or commit/PR links
+- **Verified:** commands run and relevant results
+- **Decisions:** choices future work must preserve
+- **Follow-up:** specific next actions, or "none"
+-->
+
+## Summaries
+
+_No session handoffs recorded._

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,3 +199,5 @@ Go 1.26. Use modern idioms: `any`, `slices`/`maps`/`cmp` packages, `t.Context()`
 **update documentation** After any change to source code, update relevant documentation in CLAUDE.md, README.md and the yeti/ folder. A task is not complete without reviewing and updating relevant documentation.
 
 **yeti/ directory** The `yeti/` directory contains documentation written for AI consumption and context enhancement, not primarily for humans. Jobs like `doc-maintainer` and `issue-worker` instruct the AI to read `yeti/OVERVIEW.md` and related files for codebase context before performing tasks. Write content in this directory to be maximally useful to an AI agent understanding the codebase — detailed architecture, patterns, and decision rationale rather than user-facing guides.
+
+**session handoffs** Use `.claude/session-summary.md` for concise context needed to continue unfinished work in a later session. Keep durable architecture decisions and non-obvious lessons in `yeti/learnings/` instead.


### PR DESCRIPTION
## Summary

- turn `.claude/session-summary.md` into a structured cross-session handoff artifact
- define concise content, ordering, retention, and sensitive-data guidance
- distinguish temporary session context from durable lessons in `yeti/learnings/`
- point agents to the handoff artifact from `CLAUDE.md`

The artifact initially landed through #176 for a duplicate ACMM finding, but only contained a two-line instruction. This follow-up makes it directly usable and closes the remaining finding.

## Testing

- [x] `make fmt`
- [x] `make test`
- [x] `git diff --check`

## Checklist

- [x] I have described the change clearly.
- [x] I have added/updated tests where appropriate.
- [x] I have checked this change against the [PR review rubric](https://github.com/frostyard/updex/blob/main/docs/review-rubric.md).

Closes #165
