### PR TITLE
chore: add Auto-QA tuning policy

### DIFF
--- a/.github/auto-qa-tuning.json
+++ b/.github/auto-qa-tuning.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "rolling_window_days": 30,
+  "minimum_sample_size": 10,
+  "signals": {
+    "pr_acceptance_rate": "docs/metrics.md#pull-request-acceptance"
+  },
+  "thresholds": {
+    "relative_regression": 0.1,
+    "consecutive_improved_windows_to_relax": 2
+  },
+  "actions": {
+    "pr_acceptance_rate": [
+      "tighten affected guidance in AGENTS.md, CLAUDE.md, docs/review-rubric.md, or yeti/",
+      "add or document a targeted local check when rework reveals a validation gap"
+    ]
+  },
+  "guardrails": {
+    "insufficient_data": "hold",
+    "required_checks": "never_relax",
+    "security_checks": "never_relax",
+    "coverage_checks": "never_relax",
+    "changes_via_pull_request": true
+  }
+}

--- a/docs/AI-QUALITY-ASSURANCE.md
+++ b/docs/AI-QUALITY-ASSURANCE.md
@@ -25,6 +25,18 @@ The workflow definitions and exact coverage tolerances remain versioned in
 [`codecov.yml`](../codecov.yml), so dashboard results can be traced to the
 gates that produced them.
 
+## Auto-QA self-tuning
+
+`.github/auto-qa-tuning.json` defines the machine-readable feedback policy for
+the monthly [pull request acceptance metric](metrics.md#pull-request-acceptance).
+A window with fewer than ten resolved pull requests holds the current policy.
+With enough data, a relative regression of ten percent or more routes the
+observed failure pattern to focused contributor guidance or a targeted local
+check. Relaxation requires two consecutive improved windows.
+
+Required, security, and coverage checks are never relaxed. Any policy
+adjustment must be reviewed through a pull request.
+
 ## Required checks
 
 Contributors should run the repository's standard checks before requesting


### PR DESCRIPTION
## Summary

- define a machine-readable tuning policy for the monthly PR acceptance metric
- hold tuning for small samples and require sustained improvement before relaxation
- prevent required, security, and coverage checks from being relaxed

Closes #187

## Testing

- [ ] `make fmt` (not applicable; documentation and JSON only)
- [ ] `make test` (not applicable; documentation and JSON only)
- [x] Parsed the policy with `jq` and ran `git diff --check`

## Checklist

- [x] I have described the change clearly.
- [x] I have added/updated tests where appropriate.
- [x] I have checked this change against the PR review rubric.
