### PR TITLE
docs: add change risk classification

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,19 @@
 - [ ] `make fmt`
 - [ ] `make test`
 
+## Risk classification
+
+Select one tier using the
+[change risk guide](https://github.com/frostyard/updex/blob/main/docs/risk-tiers.md):
+
+- [ ] Tier 1: Low
+- [ ] Tier 2: Moderate
+- [ ] Tier 3: High
+
+**Rationale:**
+
+-
+
 ## Checklist
 
 - [ ] I have described the change clearly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,9 @@ to rediscover belongs in `yeti/learnings/`.
    release tooling derives version bumps from them.
 4. Run `make check` and make sure it passes.
 5. Update the documentation and add tests for your change.
-6. Open the PR with a description of what changed and why, and link any
+6. Classify the change using the [risk tier guide](docs/risk-tiers.md) and
+   include the tier rationale in the pull request.
+7. Open the PR with a description of what changed and why, and link any
    related issue.
 
 Before requesting review, check the change against the

--- a/docs/review-rubric.md
+++ b/docs/review-rubric.md
@@ -7,24 +7,29 @@ introduced by the pull request.
 
 A pull request is ready to approve when all applicable gates pass:
 
-1. **Correctness and scope**
+1. **Risk classification**
+   - The author selected the highest applicable tier from the
+     [change risk guide](risk-tiers.md) and provided a rationale.
+   - The tests, analysis, documentation, and oversight required for that tier
+     are present.
+2. **Correctness and scope**
    - The change solves the linked problem and handles relevant error cases.
    - The diff is focused; unrelated refactors and generated artifacts are absent.
-2. **Architecture and API**
+3. **Architecture and API**
    - Business logic is implemented in the public SDK, with CLI code kept as a
      thin wrapper.
    - Public APIs use contexts, option structs, structured results, and compatible
      behavior unless a breaking change is intentional and documented.
-3. **Security and reliability**
+4. **Security and reliability**
    - Inputs, paths, downloaded content, and managed files are validated safely.
    - Errors do not expose credentials, and privileged filesystem operations are
      resistant to traversal and symlink attacks.
    - Multi-step mutations leave a consistent state on failure.
-4. **Tests and verification**
+5. **Tests and verification**
    - New or changed behavior has focused tests, including meaningful failure
      paths, or the pull request explains why tests are not applicable.
    - `make check` passes, including formatting, linting, and tests.
-5. **Documentation and maintainability**
+6. **Documentation and maintainability**
    - User-facing and agent-oriented documentation reflects behavior changes.
    - Code follows repository conventions and is understandable without
      unnecessary complexity.

--- a/docs/risk-tiers.md
+++ b/docs/risk-tiers.md
@@ -1,0 +1,81 @@
+# Change Risk Tiers
+
+Every pull request must declare one risk tier. The classification determines
+the review evidence and scrutiny needed in addition to the repository's normal
+CI and review gates.
+
+Choose the highest tier whose criteria match any part of the change. Consider
+blast radius, privileges and trust boundaries, reversibility, compatibility,
+and release or supply-chain impact. When uncertain, choose the higher tier.
+Reviewers may reclassify a pull request if its scope or risk changes.
+
+## Tier 1: Low
+
+Changes that do not alter runtime behavior or security boundaries.
+
+Examples include:
+
+- documentation, comments, spelling, or formatting;
+- test-only changes that do not modify production behavior;
+- mechanical refactoring with equivalent behavior; and
+- repository metadata that does not change CI permissions or release behavior.
+
+**Required evidence:** Describe the scope, explain why behavior is unchanged,
+and complete the applicable standard checks. If tests are not applicable, say
+why in the pull request.
+
+## Tier 2: Moderate
+
+Changes to normal product behavior with limited, understood impact and no
+security-sensitive or privileged boundary changes.
+
+Examples include:
+
+- compatible SDK or CLI behavior changes;
+- ordinary bug fixes and feature additions;
+- configuration parsing or output changes that do not affect a trust boundary;
+- changes spanning multiple packages; and
+- routine dependency updates that do not execute in a privileged build or
+  release path.
+
+**Required evidence:** Add focused success and failure-path tests, update
+affected user and architecture documentation, and describe compatibility,
+failure, and rollback considerations. A maintainer must confirm that the
+classification and evidence are appropriate.
+
+## Tier 3: High
+
+Changes that affect a security control, trust boundary, privileged operation,
+destructive action, broad compatibility contract, or software supply chain.
+
+Examples include:
+
+- SHA256 or GPG verification, download trust, or manifest handling;
+- untrusted input validation, paths, symlinks, archives, or privileged
+  filesystem writes;
+- secrets, credentials, GitHub Actions permissions, release automation, or
+  artifact provenance;
+- destructive operations or multi-step mutations that could leave inconsistent
+  state;
+- breaking SDK, CLI, or configuration changes; and
+- changes responding to a suspected vulnerability.
+
+**Required evidence:** Obtain explicit maintainer review of the security and
+reliability impact. Document trust boundaries, abuse and failure modes,
+compatibility impact, and rollback or recovery. Include focused adversarial and
+failure-path tests. The author or generating agent must not self-approve,
+auto-merge, weaken required checks, or disclose vulnerability details in a
+public pull request.
+
+## Classification workflow
+
+1. The author selects one tier and gives a short rationale in the pull request
+   template.
+2. Reviewers verify the tier before approval and apply the corresponding
+   requirements above.
+3. The author updates the tier and evidence if the change grows in scope.
+4. Required CI, coverage, and review gates still apply at every tier. A lower
+   tier never exempts a change from a gate or overrides a higher-risk criterion.
+
+Use private maintainer reporting channels for suspected vulnerabilities rather
+than opening a public issue or pull request.


### PR DESCRIPTION
## Summary

- define low, moderate, and high change risk tiers
- specify review evidence and oversight for each tier
- integrate classification into the PR template, review rubric, and contribution guide

## Testing

- Not run (documentation-only change)

## Risk classification

- [x] Tier 1: Low
- [ ] Tier 2: Moderate
- [ ] Tier 3: High

**Rationale:** This change adds governance documentation and template guidance without changing runtime, CI permission, or release behavior.

## Checklist

- [x] I have described the change clearly.
- [x] Tests are not applicable to this documentation-only change.
- [x] I have checked this change against the PR review rubric.

Closes #192