### PR TITLE
ci: add AI fix request workflow

### DIFF
--- a/.github/workflows/ai-fix-requested.yml
+++ b/.github/workflows/ai-fix-requested.yml
@@ -1,0 +1,79 @@
+name: AI Fix Requested
+
+on:
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to assign to Copilot
+        required: true
+        type: number
+
+permissions: {}
+
+concurrency:
+  group: ai-fix-${{ github.repository }}-${{ inputs.issue_number || github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  assign:
+    name: Assign Copilot
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'ai-fix-requested'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
+      ISSUE_NUMBER: ${{ inputs.issue_number || github.event.issue.number }}
+    steps:
+      - name: Assign requested issue
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::error::COPILOT_ASSIGN_PAT is not configured"
+            exit 1
+          fi
+          if [[ ! "$ISSUE_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Invalid issue number: $ISSUE_NUMBER"
+            exit 1
+          fi
+
+          issue="$(gh api "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER")"
+
+          if ! jq -e '.pull_request == null' <<<"$issue" >/dev/null; then
+            echo "::error::#$ISSUE_NUMBER is a pull request, not an issue"
+            exit 1
+          fi
+          if ! jq -e '.state == "open"' <<<"$issue" >/dev/null; then
+            echo "::error::Issue #$ISSUE_NUMBER is not open"
+            exit 1
+          fi
+          if ! jq -e 'any(.labels[]?; .name == "ai-fix-requested")' <<<"$issue" >/dev/null; then
+            echo "::error::Issue #$ISSUE_NUMBER does not have the ai-fix-requested label"
+            exit 1
+          fi
+          if jq -e 'any(.assignees[]?; .login == "copilot-swe-agent" or .login == "copilot-swe-agent[bot]")' <<<"$issue" >/dev/null; then
+            echo "Issue #$ISSUE_NUMBER is already assigned to Copilot." >>"$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          base_branch="$(gh api "repos/$GITHUB_REPOSITORY" --jq '.default_branch')"
+          jq -n \
+            --arg target_repo "$GITHUB_REPOSITORY" \
+            --arg base_branch "$base_branch" \
+            '{
+              assignees: ["copilot-swe-agent[bot]"],
+              agent_assignment: {
+                target_repo: $target_repo,
+                base_branch: $base_branch
+              }
+            }' |
+            gh api \
+              --method POST \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              "repos/$GITHUB_REPOSITORY/issues/$ISSUE_NUMBER/assignees" \
+              --input - >/dev/null
+
+          echo "Assigned issue #$ISSUE_NUMBER to Copilot from \`$base_branch\`." >>"$GITHUB_STEP_SUMMARY"

--- a/docs/AI-QUALITY-ASSURANCE.md
+++ b/docs/AI-QUALITY-ASSURANCE.md
@@ -18,6 +18,7 @@ coverage trends.
 | Continuous integration | [Tests workflow](https://github.com/frostyard/updex/actions/workflows/test.yml) | Lint, security, unit, end-to-end, race, verification, and build jobs pass |
 | Test coverage | [Codecov dashboard](https://codecov.io/gh/frostyard/updex) | Project coverage stays within the configured 1% threshold and changed lines meet the 70% target |
 | Pull request review | [Open pull requests](https://github.com/frostyard/updex/pulls) | Reviewers can audit the diff and CI history before merge |
+| AI fix requests | [AI Fix Requested workflow](https://github.com/frostyard/updex/actions/workflows/ai-fix-requested.yml) | Labeled issues are assigned to Copilot through an auditable workflow run |
 | Releases | [Release workflow](https://github.com/frostyard/updex/actions/workflows/release.yml) | Release artifacts are built from reviewed repository history |
 
 The workflow definitions and exact coverage tolerances remain versioned in
@@ -40,6 +41,24 @@ make build
 Changes should include focused tests when behavior changes. Reviewers should
 confirm that the implementation is limited to the requested scope, errors are
 handled safely, and no credentials or other sensitive values are present.
+
+## AI fix requests
+
+Adding the `ai-fix-requested` label to an open issue runs
+[`ai-fix-requested.yml`](../.github/workflows/ai-fix-requested.yml), which
+assigns the issue to GitHub Copilot on the repository's default branch. A
+maintainer can retry a request with the workflow's `issue_number` manual input.
+The issue must still be open and carry the label, and an issue already assigned
+to Copilot is treated as complete.
+
+The workflow requires a repository secret named `COPILOT_ASSIGN_PAT`. It must
+contain a user token from a Copilot-licensed maintainer, scoped only to this
+repository. For a fine-grained token, grant read access to metadata and
+read/write access to Actions, Contents, Issues, and Pull requests, as required
+by GitHub's agent-assignment API. The workflow does not check out issue-authored
+content or grant permissions to its `GITHUB_TOKEN`; it uses the user token only
+for fixed GitHub API requests. Failed assignments remain visibly labeled and
+can be retried after correcting the configuration.
 
 ## Human oversight
 


### PR DESCRIPTION
## Summary

- add an `ai-fix-requested` label and manual-dispatch workflow
- assign eligible issues through GitHub's official Copilot agent-assignment API
- document token setup, retry behavior, and human oversight

Closes #191

## Testing

- [x] `actionlint .github/workflows/ai-fix-requested.yml`
- [x] parsed the workflow with `yq`
- [x] linted the embedded Bash with `shellcheck`
- [x] exercised assignment and already-assigned paths against a mocked `gh api`
- [ ] `make fmt` (not applicable; no Go source changed)
- [ ] `make test` (not applicable; no Go behavior changed)

## Risk classification

- [ ] Tier 1: Low
- [ ] Tier 2: Moderate
- [x] Tier 3: High

**Rationale:** This workflow uses a maintainer-owned user token to automate a GitHub issue assignment, so it crosses a credential and repository-automation trust boundary.

**Trust boundaries:** Only actors allowed to apply repository labels or dispatch workflows can trigger assignment. The user token enters one fixed shell step through an Actions secret; issue-authored content is neither checked out nor evaluated. The built-in `GITHUB_TOKEN` receives no permissions.

**Abuse and failure modes:** The workflow rejects invalid numbers, pull requests, closed issues, and issues without the request label. It is idempotent for existing Copilot assignments and serializes duplicate requests per issue. Missing, under-scoped, or Copilot-ineligible tokens fail the run without adding a processing label, so the request remains visible and retryable.

**Compatibility and recovery:** Product and CI behavior are unchanged. Repositories without Copilot or `COPILOT_ASSIGN_PAT` get an explicit failed run. Rollback is removal of the workflow and secret; maintainers can unassign Copilot and manually retry requests after configuration is corrected.

## Checklist

- [x] I have described the change clearly.
- [x] I have added/updated tests where appropriate.
- [x] I have checked this change against the PR review rubric.
