### PR TITLE
ci: add automated pull request labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,23 @@
+documentation:
+  - changed-files:
+      - any-glob-to-any-file: "**/*.md"
+
+go:
+  - changed-files:
+      - any-glob-to-any-file: "**/*.go"
+
+github_actions:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/actions/**"
+          - ".github/dependabot.yml"
+          - ".github/labeler.yml"
+          - ".github/workflows/**"
+
+dependencies:
+  - any:
+      - head-branch: "^dependabot/"
+      - changed-files:
+          - any-glob-to-any-file:
+              - "go.mod"
+              - "go.sum"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,23 @@
+name: Pull Request Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  label:
+    name: Apply path labels
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      # pull_request_target can label fork PRs. Never check out or execute
+      # pull-request-controlled code in this privileged workflow.
+      - name: Apply labels
+        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7
+        with:
+          sync-labels: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,6 +158,11 @@ Before requesting review, check the change against the
 [pull request review rubric](docs/review-rubric.md). Reviewers use its gates and
 feedback labels to keep decisions consistent and actionable.
 
+Pull requests are automatically labeled for documentation, Go, GitHub Actions,
+and dependency changes according to [`.github/labeler.yml`](.github/labeler.yml).
+The labeler adds matching labels without removing labels applied by contributors
+or reviewers.
+
 CI runs on every pull request (`.github/workflows/test.yml`) and must pass:
 lint (golangci-lint), security scan (`govulncheck`), unit tests with coverage,
 race-detector tests, verification (`go mod tidy` cleanliness, `go vet`,


### PR DESCRIPTION
## Summary

- add deterministic rules for the existing `documentation`, `go`, `github_actions`, and `dependencies` labels
- apply labels to fork pull requests with a least-privilege, commit-pinned workflow
- document automatic labeling in the contribution guide

Closes #190

## Testing

- [x] `actionlint .github/workflows/labeler.yml`
- [x] parsed both YAML files with `yq`
- [x] verified every configured label already exists in the upstream repository
- [x] `git diff --check`
- [ ] `make fmt` (not applicable; no Go source changed)
- [ ] `make test` (not applicable; no Go behavior changed)

## Risk classification

- [ ] Tier 1: Low
- [ ] Tier 2: Moderate
- [x] Tier 3: High

**Rationale:** The workflow uses `pull_request_target` with permission to modify pull request labels, so it crosses a repository-automation trust boundary even though its scope is narrow.

**Trust boundaries:** Fork authors can trigger the workflow, but it runs the base branch definition and configuration. It never checks out or executes pull-request-controlled code. The official `actions/labeler` action is pinned to commit `bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13`, and the job token is limited to `contents: read` and `pull-requests: write`; no secrets or `issues: write` permission are exposed.

**Abuse and failure modes:** The workflow can only add pre-existing labels to the triggering pull request. Label synchronization is disabled, so automated runs do not remove contributor or reviewer labels. Configuration or API failures produce a failed workflow run without affecting product code or CI gates.

**Compatibility and recovery:** Runtime and build behavior are unchanged. GitHub-hosted runners support the action's Node 24 runtime. Rollback consists of removing the workflow and configuration; any incorrectly applied labels can be removed manually.

## Checklist

- [x] I have described the change clearly.
- [x] I have added/updated tests where appropriate.
- [x] I have checked this change against the PR review rubric.
