### PR TITLE
ci: automate Copilot pull request reviews

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,6 +17,14 @@ updex is a Go library (SDK) and CLI tool for managing systemd-sysext images, rep
 - **Main Use Case**: Automated downloading, verification, and installation of system extension images from remote HTTP sources
 - **Key Value**: Provides a lightweight, secure way to manage system extensions with version control, GPG verification, and automatic cleanup
 
+## Pull Request Reviews
+
+Apply the gates in [`docs/review-rubric.md`](../docs/review-rubric.md) to every
+pull request review. Classify feedback as blocking, non-blocking, question, or
+nit; explain the impact of each finding and suggest a concrete resolution.
+Treat automated feedback as advisory: do not approve changes, weaken required
+checks, or claim verification passed without evidence from the pull request.
+
 ### Tech Stack
 
 - **Language**: Go 1.25

--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -1,0 +1,58 @@
+name: Automated Copilot Review
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions: {}
+
+concurrency:
+  group: auto-review-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  request-review:
+    name: Request Copilot review
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      # pull_request_target permits review requests for fork PRs. Never check
+      # out or execute pull-request-controlled code in this workflow.
+      - name: Request review
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Invalid pull request number: $PR_NUMBER"
+            exit 1
+          fi
+
+          response="$(
+            jq -n '{reviewers: ["copilot-pull-request-reviewer[bot]"]}' |
+              gh api \
+                --method POST \
+                --header "Accept: application/vnd.github+json" \
+                --header "X-GitHub-Api-Version: 2022-11-28" \
+                "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/requested_reviewers" \
+                --input -
+          )"
+
+          if ! jq -e '
+            any(
+              .requested_reviewers[]?;
+              .login == "copilot-pull-request-reviewer" or
+              .login == "copilot-pull-request-reviewer[bot]"
+            )
+          ' <<<"$response" >/dev/null; then
+            echo "::error::GitHub did not add Copilot as a requested reviewer"
+            exit 1
+          fi
+
+          echo "Requested a Copilot review for pull request #$PR_NUMBER." >>"$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- automatically request Copilot review for every non-draft pull request and new push
- direct Copilot reviews to the repository's review rubric and impact categories
- keep automated review advisory and separate from required human approval and CI

Closes #189

## Testing

- [x] `actionlint .github/workflows/auto-review.yml`
- [x] parsed the workflow with `yq`
- [x] linted the embedded Bash with `shellcheck`
- [x] exercised accepted and missing-reviewer API responses against a mocked `gh api`
- [x] `git diff --check`
- [ ] `make fmt` (not applicable; no Go source changed)
- [ ] `make test` (not applicable; no Go behavior changed)

## Risk classification

- [ ] Tier 1: Low
- [ ] Tier 2: Moderate
- [x] Tier 3: High

**Rationale:** The workflow uses `pull_request_target` and a write-capable repository token to request reviews, crossing a repository-automation trust boundary.

**Trust boundaries:** Fork authors can trigger the workflow, but it runs only the base branch workflow. It never checks out or executes pull-request-controlled code and exposes no repository secrets. The job token grants only `pull-requests: write`; all repository and pull request identifiers come from the trusted event context. Copilot may read head-branch instructions as part of its review, so its findings remain advisory and cannot satisfy required approvals.

**Abuse and failure modes:** Draft pull requests are skipped. Repeated pushes can request re-review, while per-PR concurrency cancels stale workflow runs. The step verifies that GitHub actually returned Copilot as a requested reviewer and fails visibly if Copilot review is disabled, unavailable, or rate-limited. It does not approve, merge, push commits, change labels, or weaken checks.

**Compatibility and recovery:** Product and build behavior are unchanged. The repository must have Copilot code review enabled for requests to succeed. Rollback consists of removing the workflow; pending review requests can be removed through the pull request UI.

## Checklist

- [x] I have described the change clearly.
- [x] I have added/updated tests where appropriate.
- [x] I have checked this change against the PR review rubric.
