### PR TITLE
ci: add nightly compliance checks

### DIFF
--- a/.github/workflows/nightly-compliance.yml
+++ b/.github/workflows/nightly-compliance.yml
@@ -1,0 +1,59 @@
+name: Nightly compliance
+
+on:
+  schedule:
+    - cron: '27 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-compliance
+  cancel-in-progress: false
+
+jobs:
+  compliance:
+    name: Dependency and regression compliance
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v6.0.0
+        with:
+          go-version: '1.26.5'
+          cache: true
+
+      - name: Verify dependency content
+        run: |
+          go mod download
+          go mod verify
+
+      - name: Verify module graph is reproducible
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+
+      - name: Install pinned vulnerability scanner
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
+
+      - name: Scan reachable code for known vulnerabilities
+        run: govulncheck ./...
+
+      - name: Run uncached tests with race detection
+        run: go test -race -count=1 ./...
+
+      - name: Run static analysis
+        run: go vet ./...
+
+      - name: Cross-build supported Linux targets
+        run: |
+          for arch in amd64 arm64; do
+            CGO_ENABLED=0 GOOS=linux GOARCH="$arch" \
+              go build -o "/tmp/updex-linux-$arch" ./cmd/updex-cli
+          done

--- a/docs/AI-QUALITY-ASSURANCE.md
+++ b/docs/AI-QUALITY-ASSURANCE.md
@@ -16,14 +16,30 @@ coverage trends.
 | Signal | Live view | Quality gate |
 | --- | --- | --- |
 | Continuous integration | [Tests workflow](https://github.com/frostyard/updex/actions/workflows/test.yml) | Lint, security, unit, end-to-end, race, verification, and build jobs pass |
+| Nightly compliance | [Nightly compliance workflow](https://github.com/frostyard/updex/actions/workflows/nightly-compliance.yml) | Dependency integrity, current vulnerability data, uncached race tests, static analysis, and supported Linux builds pass |
 | Test coverage | [Codecov dashboard](https://codecov.io/gh/frostyard/updex) | Project coverage stays within the configured 1% threshold and changed lines meet the 70% target |
 | Pull request review | [Open pull requests](https://github.com/frostyard/updex/pulls) | Reviewers can audit the diff and CI history before merge |
 | Releases | [Release workflow](https://github.com/frostyard/updex/actions/workflows/release.yml) | Release artifacts are built from reviewed repository history |
 
 The workflow definitions and exact coverage tolerances remain versioned in
-[`.github/workflows/test.yml`](../.github/workflows/test.yml) and
-[`codecov.yml`](../codecov.yml), so dashboard results can be traced to the
+[`.github/workflows/test.yml`](../.github/workflows/test.yml),
+[`.github/workflows/nightly-compliance.yml`](../.github/workflows/nightly-compliance.yml),
+and [`codecov.yml`](../codecov.yml), so dashboard results can be traced to the
 gates that produced them.
+
+## Nightly compliance
+
+The nightly workflow runs against the latest default-branch revision at 03:27
+UTC and can also be dispatched manually. It re-verifies downloaded module
+content, requires `go mod tidy` to remain clean, queries the current Go
+vulnerability database with a pinned scanner, runs the complete suite uncached
+under the race detector, runs `go vet`, and cross-builds the supported Linux
+architectures.
+
+The job has read-only repository permissions, persists no checkout credentials,
+uses no secrets, and never publishes or modifies repository state. A failure is
+a signal for maintainer investigation; it does not automatically weaken a gate
+or modify code.
 
 ## Required checks
 


### PR DESCRIPTION
## Summary

- add a daily and manually dispatchable nightly compliance workflow
- verify module integrity and reproducible dependency metadata
- scan reachable code against current vulnerability data with a pinned scanner
- run uncached race tests, static analysis, and Linux amd64/arm64 builds
- expose the nightly signal and its security boundaries in the AI quality dashboard

Closes #188

## Safety

- read-only repository permissions
- checkout credentials are not persisted
- no secrets, publishing, or repository mutation
- pinned third-party Actions and vulnerability-scanner version

## Validation

- `actionlint .github/workflows/nightly-compliance.yml`
- `go mod verify`; `go mod tidy` remained clean
- `go vet ./...`
- `go test -race -count=1 ./...`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...` (no vulnerabilities found)
- cross-builds succeeded for linux/amd64 and linux/arm64
- `git diff --check`