### PR TITLE
fix(ci): pin credential-bearing release actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
       - name: Publish to frostyard repo
-        uses: frostyard/repogen/.github/actions/publish-to-r2@main
+        uses: frostyard/repogen/.github/actions/publish-to-r2@6648671cec7015231fac1f278f09ee5799281bc9 # main
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -58,7 +58,7 @@ jobs:
       - name: Kickoff snosi
         if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         continue-on-error: true
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
           token: ${{ secrets.ORG_PAT }}
           repository: frostyard/snosi


### PR DESCRIPTION
## Summary
- pin the repogen R2 publishing action to commit 6648671cec7015231fac1f278f09ee5799281bc9
- pin repository-dispatch v4 to commit 28959ce8df70de7be546dd1250a005dd32156697
- retain ref comments so automated dependency updates remain understandable

This prevents mutable upstream refs from changing the code that receives Cloudflare, R2, GPG, and organization credentials during releases.

## Validation
- actionlint release workflow
- verified both action definitions exist at the pinned commits
- git diff check

Closes #207