### PR TITLE
ci: make unavailable Copilot review advisory

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -34,7 +34,7 @@ jobs:
             exit 1
           fi
 
-          response="$(
+          if ! response="$(
             jq -n '{reviewers: ["copilot-pull-request-reviewer[bot]"]}' |
               gh api \
                 --method POST \
@@ -42,17 +42,21 @@ jobs:
                 --header "X-GitHub-Api-Version: 2022-11-28" \
                 "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/requested_reviewers" \
                 --input -
-          )"
+          )"; then
+            echo "::warning::GitHub did not accept the Copilot review request; verify Copilot code review is enabled"
+            echo "⚠️ GitHub did not accept the Copilot review request for pull request #$PR_NUMBER." >>"$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
 
-          if ! jq -e '
+          if jq -e '
             any(
               .requested_reviewers[]?;
               .login == "copilot-pull-request-reviewer" or
               .login == "copilot-pull-request-reviewer[bot]"
             )
           ' <<<"$response" >/dev/null; then
-            echo "::error::GitHub did not add Copilot as a requested reviewer"
-            exit 1
+            echo "Requested a Copilot review for pull request #$PR_NUMBER." >>"$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::GitHub accepted the request but did not confirm Copilot as a requested reviewer"
+            echo "⚠️ GitHub did not confirm Copilot as a reviewer for pull request #$PR_NUMBER." >>"$GITHUB_STEP_SUMMARY"
           fi
-
-          echo "Requested a Copilot review for pull request #$PR_NUMBER." >>"$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- emit an Actions warning instead of failing when GitHub accepts the request but omits Copilot from `requested_reviewers`
- also soft-fail API rejection, which covers repositories where Copilot code review is unavailable or disabled
- report confirmed, unconfirmed, and rejected outcomes accurately in the step summary
- retain hard failure for malformed pull request numbers

This keeps the optional reviewer best-effort and prevents it from making otherwise healthy PRs red. Maintainers should still verify Copilot code review under **Settings → Copilot**.

Fixes #206

## Testing

- [x] `make fmt`
- [x] `actionlint .github/workflows/auto-review.yml`
- [x] `bash -n` on the extracted embedded script
- [x] mocked `gh api` for confirmed, unconfirmed, and rejected responses (all expected exit status and summaries)
- [x] `git diff --check`

## Risk classification

- [ ] Tier 1: Low
- [x] Tier 2: Moderate
- [ ] Tier 3: High

**Rationale:** This changes CI failure semantics but does not alter product code or grant additional permissions.

**Trust boundaries:** The `pull_request_target` workflow still does not check out or execute PR-controlled code. Token permissions remain limited to `pull-requests: write`, and the PR number still comes from validated event context.

**Failure mode and recovery:** A Copilot request failure is now visible as an annotation and step-summary warning rather than a failed check. Revert this commit to restore hard-failure behavior.
