### PR TITLE
docs: make SDK quick-start compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,15 @@ make install
 The SDK is built around a `Client` struct that provides all operations:
 
 ```go
-import "github.com/frostyard/updex/updex"
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/frostyard/updex/updex"
+)
 
 func main() {
     client := updex.NewClient(updex.ClientConfig{


### PR DESCRIPTION
## Summary

- Add the missing `package main` declaration to the SDK quick-start.
- Import `context`, `fmt`, and `log` alongside the Updex SDK so the complete block can be copied into a Go file and compiled as written.

Closes #217

## Testing

- [ ] `make fmt` (not applicable; no Go source files changed)
- [ ] `make test` (not applicable; SDK behavior is unchanged)
- [x] Extracted the README's first Go block into a temporary module, replaced `github.com/frostyard/updex` with this checkout, and ran `go test .` successfully.
- [x] `git diff --check`

## Risk classification

Select one tier using the
[change risk guide](https://github.com/frostyard/updex/blob/main/docs/risk-tiers.md):

- [x] Tier 1: Low
- [ ] Tier 2: Moderate
- [ ] Tier 3: High

**Rationale:**

This is a documentation-only correction that makes the example syntactically complete. It does not change SDK or CLI behavior.

## Checklist

- [x] I have described the change clearly.
- [x] I have added/updated tests where appropriate.
- [x] I have checked this change against the
  [PR review rubric](https://github.com/frostyard/updex/blob/main/docs/review-rubric.md).
