### PR TITLE
fix(ci): handle asynchronous Copilot reviews

### DIFF
--- a/.github/workflows/auto-review.yml
+++ b/.github/workflows/auto-review.yml
@@ -34,29 +34,19 @@ jobs:
             exit 1
           fi
 
-          if ! response="$(
-            jq -n '{reviewers: ["copilot-pull-request-reviewer[bot]"]}' |
-              gh api \
-                --method POST \
-                --header "Accept: application/vnd.github+json" \
-                --header "X-GitHub-Api-Version: 2022-11-28" \
-                "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/requested_reviewers" \
-                --input -
-          )"; then
+          # Copilot review requests are asynchronous. A successful API response may
+          # omit Copilot from requested_reviewers even though a review is queued.
+          if ! jq -n '{reviewers: ["copilot-pull-request-reviewer[bot]"]}' |
+            gh api \
+              --method POST \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/requested_reviewers" \
+              --input - \
+              --silent; then
             echo "::warning::GitHub did not accept the Copilot review request; verify Copilot code review is enabled"
             echo "⚠️ GitHub did not accept the Copilot review request for pull request #$PR_NUMBER." >>"$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
-          if jq -e '
-            any(
-              .requested_reviewers[]?;
-              .login == "copilot-pull-request-reviewer" or
-              .login == "copilot-pull-request-reviewer[bot]"
-            )
-          ' <<<"$response" >/dev/null; then
-            echo "Requested a Copilot review for pull request #$PR_NUMBER." >>"$GITHUB_STEP_SUMMARY"
-          else
-            echo "::warning::GitHub accepted the request but did not confirm Copilot as a requested reviewer"
-            echo "⚠️ GitHub did not confirm Copilot as a reviewer for pull request #$PR_NUMBER." >>"$GITHUB_STEP_SUMMARY"
-          fi
+          echo "Submitted a Copilot review request for pull request #$PR_NUMBER." >>"$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- treat a successful reviewer API response as submission of the asynchronous Copilot review request
- stop requiring Copilot to appear in `requested_reviewers` in the immediate response
- preserve the advisory warning when GitHub rejects the request

The investigation confirmed the workflow token has `pull-requests: write`. Run 31294453543 returned a successful API response without listing Copilot, then Copilot submitted its review on PR #223 seconds later. The response-body assertion was therefore producing a false warning rather than validating delivery.

Closes #218

## Testing

- [ ] `make fmt` (not applicable; workflow-only change)
- [ ] `make test` (not applicable; workflow-only change)
- [x] `actionlint .github/workflows/auto-review.yml`
- [x] `bash -n` on the extracted embedded script
- [x] mocked successful and rejected `gh api` paths
- [x] `git diff --check`

## Risk classification

- [ ] Tier 1: Low
- [x] Tier 2: Moderate
- [ ] Tier 3: High

**Rationale:** This changes CI reporting for a privileged `pull_request_target` workflow, but does not expand permissions or execute pull-request-controlled code.

## Checklist

- [x] I have described the change clearly.
- [x] I have added/updated tests where appropriate.
- [x] I have checked this change against the PR review rubric.