### PR TITLE
docs: make SDK quick-start runnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,17 @@ make install
 
 ## Library (SDK) Usage
 
-The SDK is built around a `Client` struct that provides all operations:
+Create a module for the example:
+
+```bash
+mkdir updex-quickstart
+cd updex-quickstart
+go mod init example.com/updex-quickstart
+go get github.com/frostyard/updex/updex
+```
+
+Save the following as `main.go`. The SDK is built around a `Client` struct
+that provides all operations:
 
 ```go
 package main
@@ -137,6 +147,16 @@ func main() {
     }
 }
 ```
+
+Run the example from the module directory:
+
+```bash
+go run .
+```
+
+The enable, update, and disable calls change system state. Run the complete
+example only on a configured test system with permission to manage system
+extensions.
 
 ### Client Methods
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,15 @@ make install
 The SDK is built around a `Client` struct that provides all operations:
 
 ```go
-import "github.com/frostyard/updex/updex"
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/frostyard/updex/updex"
+)
 
 func main() {
     client := updex.NewClient(updex.ClientConfig{


### PR DESCRIPTION
## Summary

- Make the SDK example a complete Go program with `package main` and all required standard-library imports.
- Add the minimal module initialization, dependency installation, and `go run .` commands needed to execute it.
- Warn that the example's enable, update, and disable calls require an appropriately configured test system and permissions.

This supersedes #224 with the complete fix requested by both issues.

Closes #217
Closes #221

## Testing

- [ ] `make fmt` (not applicable; no Go source files changed)
- [ ] `make test` (not applicable; SDK behavior is unchanged)
- [x] Extracted the README Go block into a fresh module, replaced `github.com/frostyard/updex` with this checkout, and ran `go test .` successfully.
- [x] `git diff --check`

## Risk classification

Select one tier using the
[change risk guide](https://github.com/frostyard/updex/blob/main/docs/risk-tiers.md):

- [x] Tier 1: Low
- [ ] Tier 2: Moderate
- [ ] Tier 3: High

**Rationale:**

This is a documentation-only onboarding correction and does not change SDK or CLI behavior.

## Checklist

- [x] I have described the change clearly.
- [x] I have added/updated tests where appropriate.
- [x] I have checked this change against the
  [PR review rubric](https://github.com/frostyard/updex/blob/main/docs/review-rubric.md).