### PR TITLE
ci: add timeouts to release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   snapshot:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # Only run if the Tests workflow succeeded
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:


### PR DESCRIPTION
## Summary

- cap the release GoReleaser job at 30 minutes
- cap the snapshot GoReleaser job at 30 minutes
- limit how long hung jobs retain GitHub, GoReleaser, and cloud publishing credentials

Closes #233